### PR TITLE
Ability to refresh mqtt password at every reconnection

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Connect to MQTT Broker:
                    | {proto_ver, mqtt_vsn()}
                    | {username, binary()}
                    | {password, binary()}
-                   | {password_refresher, fun()}
+                   | {password_refresher, fun() | undefined}
                    | {will, list(tuple())}
                    | {connack_timeout, pos_integer()}
                    | {puback_timeout,  pos_integer()}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ emqttc requires Erlang R17+.
 
 ## Usage
 
-### simple 
+### simple
 
 examples/simple_example.erl
 
@@ -63,7 +63,7 @@ init(_Args) ->
 handle_info({publish, Topic, Payload}, State) ->
     io:format("Message from ~s: ~p~n", [Topic, Payload]),
     {noreply, State};
-    
+
 %% Client connected
 handle_info({mqttc, C, connected}, State = #state{mqttc = C}) ->
     io:format("Client ~p is connected~n", [C]),
@@ -71,7 +71,7 @@ handle_info({mqttc, C, connected}, State = #state{mqttc = C}) ->
     emqttc:subscribe(C, <<"TopicB">>, 2),
     self() ! publish,
     {noreply, State};
-    
+
 %% Client disconnected
 handle_info({mqttc, C,  disconnected}, State = #state{mqttc = C}) ->
     io:format("Client ~p is disconnected~n", [C]),
@@ -111,6 +111,7 @@ Connect to MQTT Broker:
                    | {proto_ver, mqtt_vsn()}
                    | {username, binary()}
                    | {password, binary()}
+                   | {password_refresher, fun()}
                    | {will, list(tuple())}
                    | {connack_timeout, pos_integer()}
                    | {puback_timeout,  pos_integer()}
@@ -125,10 +126,10 @@ Connect to MQTT Broker:
 Option | Value | Default | Description | Example
 -------|-------|---------|-------------|---------
 host   | inet:ip_address() or string() | "locahost" | Broker Address | "locahost"
-port   | inet:port_number() | 1883 | Broker Port | 
+port   | inet:port_number() | 1883 | Broker Port |
 client_id | binary() | random clientId | MQTT ClientId | <<"slimpleClientId">>
-clean_sess | boolean() | true | MQTT CleanSession | 
-keepalive | non_neg_integer() | 60 | MQTT KeepAlive(secs) 
+clean_sess | boolean() | true | MQTT CleanSession |
+keepalive | non_neg_integer() | 60 | MQTT KeepAlive(secs)
 proto_ver | mqtt_vsn()			| 4 | MQTT Protocol Version | 3,4
 username | binary()
 password | binary()
@@ -221,7 +222,7 @@ Reconnect Policy: <code>{MinInterval, MaxInterval, MaxRetries}</code>.
 
 ```erlang
 
-%% reconnect with 4(secs) min interval, 60 max interval  
+%% reconnect with 4(secs) min interval, 60 max interval
 emqttc:start_link([{reconnect, 4}]).
 
 %% reconnect with 3(secs) min interval, 120(secs) max interval and 10 max retries.
@@ -235,7 +236,7 @@ emqttc:start_link([{reconnect, {3, 120, 10}}]).
 
 ```erlang
 
-%% Resubscribe topics automatically when reconnected.  
+%% Resubscribe topics automatically when reconnected.
 emqttc:start_link([auto_resub, {reconnect, 4}]).
 
 ```
@@ -324,7 +325,7 @@ emqttc:disconnect(Client).
 emqttc:topics(Client).
 ```
 
-## Design 
+## Design
 
 ![Design](https://raw.githubusercontent.com/emqtt/emqttc/master/doc/Socket.png)
 

--- a/src/emqttc_protocol.erl
+++ b/src/emqttc_protocol.erl
@@ -122,6 +122,9 @@ init_willmsg([{retain, Retain} | Opts], WillMsg) when is_boolean(Retain) ->
 init_willmsg([_Opt | Opts], State) ->
     init_willmsg(Opts, State).
 
+refresh_password([{password_refresher, undefined}], State) ->
+    init([], State);
+
 refresh_password([{password_refresher, PasswordRefresher}], State) when is_function(PasswordRefresher) ->
     init([], State#proto_state{password = PasswordRefresher()}).
 

--- a/src/emqttc_protocol.erl
+++ b/src/emqttc_protocol.erl
@@ -45,6 +45,7 @@
          unsubscribe/2,
          ping/1,
          disconnect/1,
+         refresh_password/2,
          received/2]).
 
 -record(proto_state, {
@@ -100,6 +101,8 @@ init([{username, Username} | Opts], State) when is_binary(Username)->
     init(Opts, State#proto_state{username = Username});
 init([{password, Password} | Opts], State) when is_binary(Password) ->
     init(Opts, State#proto_state{password = Password});
+init([{password_refresher, PasswordRefresher} | Opts], State) when is_function(PasswordRefresher) ->
+    init(Opts, State#proto_state{password = PasswordRefresher()});
 init([{will, WillOpts} | Opts], State = #proto_state{will_msg = WillMsg}) ->
     init(Opts, State#proto_state{will_flag = true,
                                  will_msg  = init_willmsg(WillOpts, WillMsg)});
@@ -118,6 +121,9 @@ init_willmsg([{retain, Retain} | Opts], WillMsg) when is_boolean(Retain) ->
     init_willmsg(Opts, WillMsg#mqtt_message{retain = Retain});
 init_willmsg([_Opt | Opts], State) ->
     init_willmsg(Opts, State).
+
+refresh_password([{password_refresher, PasswordRefresher}], State) when is_function(PasswordRefresher) ->
+    init([], State#proto_state{password = PasswordRefresher()}).
 
 random_id() ->
     random:seed(case erlang:function_exported(erlang, timestamp, 0) of

--- a/test/emqttc_test.erl
+++ b/test/emqttc_test.erl
@@ -66,6 +66,13 @@ clean_sess_test() ->
     emqttc:publish(C2, <<"Topic1">>, <<"Playload">>, [{qos, 1}]),
     emqttc:disconnect(C2).
 
+password_refresher_test() ->
+    PasswordRefresher = fun() -> <<"1234">> end,
+    {ok, C} = start_client([{client_id, <<"testClient">>}, {password_refresher, PasswordRefresher}]),
+    timer:sleep(1000),
+    pong = emqttc:ping(C),
+    emqttc:disconnect(C).
+
 start_client() ->
     emqttc:start_link([{logger, {error_logger, info}}]).
 

--- a/test/emqttc_test.erl
+++ b/test/emqttc_test.erl
@@ -73,6 +73,13 @@ password_refresher_test() ->
     pong = emqttc:ping(C),
     emqttc:disconnect(C).
 
+password_refresher_can_be_undefined_test() ->
+    PasswordRefresher = undefined,
+    {ok, C} = start_client([{client_id, <<"testClient">>}, {password_refresher, PasswordRefresher}]),
+    timer:sleep(1000),
+    pong = emqttc:ping(C),
+    emqttc:disconnect(C).
+
 start_client() ->
     emqttc:start_link([{logger, {error_logger, info}}]).
 


### PR DESCRIPTION
Hi, we have a scenario where every time we generate a password to the MQTT, this password may have some security constraints, i.e expiration time, depending on the MQTT module implementation.

Sometimes the `tcp` connection may be closed or the `emqttc` process might fail for any reason, then we'd like to use the same process to retry over again but using a different password. 

This patch adds the ability to send a `password_refresher` to the mqtt connection opts, a simple function which will be called at every connect/reconnect.

### Usage
```
PasswordRefresher = fun() -> <<"logic to generate a new password">> end,
{ok, C} = emqttc:start_link([{host, "localhost"}, {password_refresher, PasswordRefresher}]).
```
