### PR TITLE
Fix shutdown reason in case of connect error

### DIFF
--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -625,8 +625,8 @@ initialized({call, From}, {connect, ConnMod}, State = #state{sock_opts = SockOpt
                 Error = {error, Reason} ->
                     {stop_and_reply, Reason, [{reply, From, Error}]}
             end;
-        Error = {error, Reason} ->
-            {stop_and_reply, Reason, [{reply, From, Error}]}
+        Error ->
+            {stop_and_reply, normal, [{reply, From, Error}]}
     end;
 
 initialized(EventType, EventContent, State) ->

--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -625,8 +625,8 @@ initialized({call, From}, {connect, ConnMod}, State = #state{sock_opts = SockOpt
                 Error = {error, Reason} ->
                     {stop_and_reply, Reason, [{reply, From, Error}]}
             end;
-        Error ->
-            {stop_and_reply, normal, [{reply, From, Error}]}
+        Error = {error, Reason} ->
+            {stop_and_reply, {shutdown, Reason}, [{reply, From, Error}]}
     end;
 
 initialized(EventType, EventContent, State) ->


### PR DESCRIPTION
There is an error reported by logger when connecting to the server fails. This is I believe also what #84 mentions. Changing the stop reason to normal instead of the socket connection error avoids this.