### PR TITLE
Add logger mfa metadata to enable module level

### DIFF
--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -223,7 +223,7 @@
 
 -define(LOG(Level, Format, Args, State),
         begin
-          (logger:log(Level, #{}, #{report_cb => fun(_) -> {"emqtt(~s): "++(Format), ([State#state.clientid|Args])} end}))
+          (logger:log(Level, #{}, #{mfa => {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY}, report_cb => fun(_) -> {"emqtt(~s): "++(Format), ([State#state.clientid|Args])} end}))
         end).
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
emqtt is quite noisy on debug log level, making it trickier to debug other applications in the umbrella/release. With this change we can change the log level in logger for the emqtt module.