### PR TITLE
Add start link option low_mem 

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -68,6 +68,7 @@ jobs:
         runs-on: ubuntu-latest
 
         needs: [build, build-on-mac]
+        if: ${{ github.event_name == 'release' }}
 
         steps:
         - uses: actions/checkout@v2

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -115,7 +115,7 @@ jobs:
           run: |
             curl "https://d1vvhvl2y92vvt.cloudfront.net/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
             unzip awscliv2.zip
-            sudo ./aws/install
+            sudo ./aws/install --update
             aws configure set aws_access_key_id ${{ secrets.AwsAccessKeyId }}
             aws configure set aws_secret_access_key ${{ secrets.AwsSecretAccessKey }}
             aws configure set default.region us-west-2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,81 @@
+name: Release
+on:
+  release:
+    types:
+      - published
+      - prereleased
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    needs: [build, build-on-mac]
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/download-artifact@v1
+      with:
+        name: packages-ubuntu18.04
+        path: _packages
+    - uses: actions/download-artifact@v1
+      with:
+        name: packages-ubuntu16.04
+        path: _packages
+    - uses: actions/download-artifact@v1
+      with:
+        name: packages-ubuntu14.04
+        path: _packages
+    - uses: actions/download-artifact@v1
+      with:
+        name: packages-debian10
+        path: _packages
+    - uses: actions/download-artifact@v1
+      with:
+        name: packages-debian9
+        path: _packages
+    - uses: actions/download-artifact@v1
+      with:
+        name: packages-debian8
+        path: _packages
+    - uses: actions/download-artifact@v1
+      with:
+        name: packages-opensuse
+        path: _packages
+    - uses: actions/download-artifact@v1
+      with:
+        name: packages-centos7
+        path: _packages
+    - uses: actions/download-artifact@v1
+      with:
+        name: packages-centos6
+        path: _packages
+    - uses: actions/download-artifact@v1
+      with:
+        name: packages-mac
+        path: _packages
+    - name: set aws
+      run: |
+        curl "https://d1vvhvl2y92vvt.cloudfront.net/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+        unzip awscliv2.zip
+        sudo ./aws/install --update
+        aws configure set aws_access_key_id ${{ secrets.AwsAccessKeyId }}
+        aws configure set aws_secret_access_key ${{ secrets.AwsSecretAccessKey }}
+        aws configure set default.region us-west-2
+    - name: get packages
+      run: |
+        cd _packages && for var in $( ls |grep emqtt |grep -v sha256); do
+          echo "$(cat $var.sha256) $var" | sha256sum -c || exit 1
+        done
+    - name: upload aws
+      if: github.event_name == 'release'
+      run: |
+        version=$(echo ${{ github.ref }} | sed -r  "s .*/.*/(.*) \1 g")
+        aws s3 cp --recursive ./_packages  s3://packages.emqx.io/emqtt/$version
+        aws cloudfront create-invalidation --distribution-id E3TYD0WSP4S14P --paths "/emqtt/$version/*"
+    - name: upload github
+      if: github.event_name == 'release'
+      run: |
+        version=$(echo ${{ github.ref }} | sed -r  "s .*/.*/(.*) \1 g")
+        for var in $(ls _packages) ; do
+            .github/workflows/script/upload_github_release_asset.sh owner=emqx repo=emqtt tag=$version filename=_packages/$var github_api_token=$(echo ${{ secrets.AccessToken }})
+        done

--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -919,6 +919,7 @@ connected(cast, ?DISCONNECT_PACKET(ReasonCode, Properties), State) ->
 connected(info, {timeout, _TRef, keepalive}, State = #state{force_ping = true}) ->
     case send(?PACKET(?PINGREQ), State) of
         {ok, NewState} ->
+            erlang:garbage_collect(self(), [{type, major}]),
             {keep_state, ensure_keepalive_timer(NewState)};
         Error -> {stop, Error}
     end;

--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -136,6 +136,7 @@
                 | {auto_ack, boolean()}
                 | {ack_timeout, pos_integer()}
                 | {force_ping, boolean()}
+                | {low_mem, boolean()}
                 | {properties, properties()}).
 
 -type(maybe(T) :: undefined | T).
@@ -204,6 +205,7 @@
           retry_timer     :: reference(),
           session_present :: boolean(),
           last_packet_id  :: packet_id(),
+          low_mem         :: boolean(),
           parse_state     :: emqtt_frame:parse_state()
          }).
 
@@ -245,11 +247,19 @@ start_link(Options) when is_map(Options) ->
 start_link(Options) when is_list(Options) ->
     ok = emqtt_props:validate(
             proplists:get_value(properties, Options, #{})),
+    StatmOpts = case proplists:get_bool(low_mem, Options) of
+                    false -> [];
+                    true ->
+                        [{spawn_opt, [{min_heap_size, 16}]},
+                         {hibernate_after, 10}
+                        ]
+                end,
+
     case proplists:get_value(name, Options) of
         undefined ->
-            gen_statem:start_link(?MODULE, [with_owner(Options)], []);
+            gen_statem:start_link(?MODULE, [with_owner(Options)], StatmOpts);
         Name when is_atom(Name) ->
-            gen_statem:start_link({local, Name}, ?MODULE, [with_owner(Options)], [])
+            gen_statem:start_link({local, Name}, ?MODULE, [with_owner(Options)], StatmOpts)
     end.
 
 with_owner(Options) ->
@@ -483,6 +493,7 @@ init([Options]) ->
                                  ack_timeout     = ?DEFAULT_ACK_TIMEOUT,
                                  retry_interval  = ?DEFAULT_RETRY_INTERVAL,
                                  connect_timeout = ?DEFAULT_CONNECT_TIMEOUT,
+                                 low_mem         = false,
                                  last_packet_id  = 1
                                 }),
     {ok, initialized, init_parse_state(State)}.
@@ -592,6 +603,8 @@ init([{retry_interval, I} | Opts], State) ->
     init(Opts, State#state{retry_interval = timer:seconds(I)});
 init([{bridge_mode, Mode} | Opts], State) when is_boolean(Mode) ->
     init(Opts, State#state{bridge_mode = Mode});
+init([{low_mem, IsLow} | Opts], State) when is_boolean(IsLow) ->
+    init(Opts, State#state{low_mem = IsLow});
 init([_Opt | Opts], State) ->
     init(Opts, State).
 


### PR DESCRIPTION
Add start link option `low_mem` mode, this PR is for emqtt_bench to have as many clients as possible but keep memory usage low.

That is achieved by
1.  forcing major GC 
1.  hibernate client proc after a 50ms receive timeout.

default: disabled
