### PR TITLE
fix #141

### DIFF
--- a/src/emqtt.appup.src
+++ b/src/emqtt.appup.src
@@ -1,22 +1,13 @@
 %% -*-: erlang -*-
-{"1.2.3.1",
-  [ {"1.2.3", [
-     {load_module, emqtt, brutal_purge, soft_purge, []},
-     {load_module, emqtt_frame, brutal_purge, soft_purge, []}
-    ]},
-   {<<"1.2.[0-2]">>, [
-     {load_module, emqtt_sock, brutal_purge, soft_purge, []},
+{"1.4.5",
+  [ {"1.4.4", [
      {load_module, emqtt, brutal_purge, soft_purge, []}
-    ]}
+    ]},
+   {<<"1\\.4\\.[0-3]+">>, []} %% No appup maintained for these versions
   ],
-  [
-   {"1.2.3", [
-     {load_module, emqtt, brutal_purge, soft_purge, []},
-     {load_module, emqtt_frame, brutal_purge, soft_purge, []}
-    ]},
-   {<<"1.2.[0-2]">>, [
-     {load_module, emqtt_sock, brutal_purge, soft_purge, []},
+  [ {"1.4.4", [
      {load_module, emqtt, brutal_purge, soft_purge, []}
-    ]}
+    ]},
+   {<<"1\\.4\\.[0-3]+">>, []} %% No appup maintained for these versions
   ]
 }.

--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -852,7 +852,7 @@ connected(cast, Packet = ?PUBLISH_PACKET(?QOS_2, _PacketId), State) ->
 connected(cast, ?PUBACK_PACKET(_PacketId, _ReasonCode, _Properties) = PubAck, State) ->
     {keep_state, delete_inflight(PubAck, State)};
 
-connected(cast, ?PUBREC_PACKET(PacketId), State = #state{inflight = Inflight}) ->
+connected(cast, ?PUBREC_PACKET(PacketId, _ReasonCode), State = #state{inflight = Inflight}) ->
 	NState = case maps:find(PacketId, Inflight) of
 				 {ok, {publish, _Msg, _Ts}} ->
 					 Inflight1 = maps:put(PacketId, {pubrel, PacketId, os:timestamp()}, Inflight),


### PR DESCRIPTION
This bug occurs when after publishing with qos2, the received processing PUBREC only matches reason_code equal to 0. But in fact, there are many possible cases of reason_code here (e.g. 0x10 - no_subscriber)