### PR TITLE
fix(emqtt): should retry after reconnect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ ct: compile
 cover:
 	$(REBAR) cover
 
-t: eunit ct cover
+test: eunit ct cover
 
 dialyzer:
 	$(REBAR) dialyzer

--- a/changlog.md
+++ b/changlog.md
@@ -1,0 +1,11 @@
+# 1.7.0
+
+## Enhancements
+
+* Added `publish_async` APIs to support asynchronous publishing. [#165](https://github.com/emqx/emqtt/pull/165)
+  Note that an incompatible update has been included, where the return format
+  of the `publish` function has been changed to `ok | {ok, publish_reply()} | {error, Reason}`
+
+## Bug fixes
+
+* Fixed inflight message retry after reconnect [#166](https://github.com/emqx/emqtt/pull/166)

--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -828,7 +828,7 @@ mqtt_connect(State = #state{clientid    = ClientId,
                                  username     = Username,
                                  password     = Password}), State).
 
-reconnect(state_timeout,  NextTimeout, #state{conn_mod = CMod} = State) ->
+reconnect(state_timeout, NextTimeout, #state{conn_mod = CMod} = State) ->
     case do_connect(CMod, State#state{clean_start = false}) of
         {ok, #state{connect_timeout = Timeout} = NewState} ->
             {next_state, waiting_for_connack, NewState, [Timeout]};


### PR DESCRIPTION
Prior to this fix, the expired retry timer may not get the chance
to refresh if it's not at the 'connected' state.

A ensure_retry_timer call is added to the state transition
from waiting_for_connack to connected