### PR TITLE
chore: fix undef function(bump gun to 1.3.7)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
            ]}.
 
 {deps, [{cowlib, "2.11.0"},
-        {gun, {git, "https://github.com/emqx/gun", {tag, "1.3.4"}}},
+        {gun, {git, "https://github.com/emqx/gun", {tag, "1.3.7"}}},
         {getopt, "1.0.2"}
        ]}.
 


### PR DESCRIPTION
https://github.com/emqx/gun/compare/1.3.4...emqx:gun:1.3.7
fix: erlang:get_stacktrace() undef on OTP24