### PR TITLE
Respect connect_timeout

### DIFF
--- a/changlog.md
+++ b/changlog.md
@@ -10,3 +10,4 @@
 ## Bug fixes
 
 * Fixed inflight message retry after reconnect [#166](https://github.com/emqx/emqtt/pull/166)
+* Respect connect_timeout [#169](https://github.com/emqx/emqtt/pull/169)

--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -889,7 +889,8 @@ waiting_for_connack(timeout, _Timeout, State) ->
         false -> {stop, connack_timeout}
     end;
 
-waiting_for_connack(EventType, EventContent, State) ->
+waiting_for_connack(EventType, EventContent,
+                    State = #state{connect_timeout = Timeout}) ->
     case handle_event(EventType, EventContent, waiting_for_connack, State) of
         {stop, Reason, NewState} ->
             case take_call(connect, NewState) of
@@ -899,6 +900,8 @@ waiting_for_connack(EventType, EventContent, State) ->
                 false ->
                     {stop, Reason, NewState}
             end;
+        keep_state_and_data ->
+            {keep_state_and_data, Timeout};
         StateCallbackResult ->
             StateCallbackResult
     end.


### PR DESCRIPTION
Prior to this commit, when the client created a TCP connection with the
server and the server did not respond with a `CONNACK` (for example
because the server is blocked due to overload), the client was stuck in
state `waiting_for_connack` without respecting the configured
`connect_timeout`.