### PR TITLE
Resend only old packets

### DIFF
--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -1518,7 +1518,7 @@ retry_send(State = #state{retry_interval = Intv, inflight = Inflight}) ->
     try
         Now = now_ts(),
         Pred = fun(_, InflightReq) ->
-                       (sent_at(InflightReq) + timer:seconds(Intv)) > Now
+                       (sent_at(InflightReq) + Intv) =< Now
                end,
         NState = retry_send(Now, emqtt_inflight:to_retry_list(Pred, Inflight), State),
         {keep_state, ensure_retry_timer(NState)}


### PR DESCRIPTION
Do not resend packets that got published within the last `retry_interval`.

Before this commit, it can happen that a packet is resent even if the `retry_interval` is 30 seconds and a packet gets acked by the server within a few milliseconds.

Also, `retry_interval` unit was used wrongly at some places. Correct usage seems to be:
* The library user defines `retry_interval` in seconds.
* Within the library, `retry_interval` is milliseconds.

Also, I removed `non_parallel_tests` since it does not have any meaning in the group properties.