### PR TITLE
quicer 0.0.111

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,8 +23,7 @@
     [{test,
         [{deps,
             [ {meck, "0.9.2"}
-            , {emqx, {git_subdir, "https://github.com/qzhuyan/emqx", {branch, "dev/william/multi-streams"}, "apps/emqx"}}
-              %% @TODO revert
+            , {emqx, {git_subdir, "https://github.com/emqx/emqx", {branch, "master"}, "apps/emqx"}}
             , {emqx_limiter, {git_subdir, "https://github.com/emqx/emqx", {branch, "master"}, "apps/emqx/src/emqx_limiter"}}
             , {proper, "1.4.0"}
             ]},

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -47,7 +47,7 @@ NewProfiles = lists:foldl(fun(Key, Acc) ->
 
 NewConfig = lists:keystore(profiles, 1, CONFIG, {profiles, NewProfiles}),
 
-Quicer = {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.0.108"}}},
+Quicer = {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.0.111"}}},
 KillQuicer = fun(C) ->
                 {deps, Deps0} = lists:keyfind(deps, 1, C),
                 {erl_opts, ErlOpts0} = lists:keyfind(erl_opts, 1, C),

--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -878,8 +878,6 @@ merge_opts(Defaults, Options) ->
           lists:usort([Opt | Acc])
       end, Defaults, Options).
 
-check_options(#state{clean_start = true, reconnect = Re}) when ?NEED_RECONNECT(Re) ->
-    error({badarg, "Reconnect mechanism is not allowed with clean_start=true"});
 check_options(State) ->
     State.
 

--- a/test/emqtt_SUITE.erl
+++ b/test/emqtt_SUITE.erl
@@ -62,8 +62,7 @@ all() ->
 
 groups() ->
     [{general, [],
-      [t_bad_options,
-       t_connect,
+      [t_connect,
        t_connect_timeout,
        t_ws_connect,
        t_subscribe,
@@ -180,14 +179,6 @@ clean_retained(Topic) ->
 
 t_props(_) ->
     ok = emqtt_props:validate(#{'Payload-Format-Indicator' => 0}).
-
-t_bad_options(_) ->
-    process_flag(trap_exit, true),
-    ?assertMatch({error, {badarg, _}}, emqtt:start_link([{reconnect, 3}, {clean_start, true}])),
-    receive
-        {'EXIT', _, {{badarg, _}, _}} -> ok
-    end,
-    process_flag(trap_exit, false).
 
 t_connect(Config) ->
     ConnFun = ?config(conn_fun, Config),


### PR DESCRIPTION
- Bump quicer to 0.0.111 for ubuntu22.04 LTS prebuild binaries.
- test with EMQX master branch since https://github.com/emqx/emqx/pull/9949 is merged
- disable force check on reconnect clean session option check since we need it for testing.