### PR TITLE
feat(connect): accept binary hosts

### DIFF
--- a/test/emqtt_SUITE.erl
+++ b/test/emqtt_SUITE.erl
@@ -16,8 +16,8 @@
 
 -module(emqtt_SUITE).
 
--compile(export_all).
 -compile(nowarn_export_all).
+-compile(export_all).
 
 -import(lists, [nth/2]).
 
@@ -64,7 +64,6 @@ groups() ->
     [{general, [],
       [t_connect,
        t_connect_timeout,
-       t_ws_connect,
        t_subscribe,
        t_subscribe_qoe,
        t_publish,
@@ -127,7 +126,7 @@ end_per_suite(_Config) ->
     emqtt_test_lib:stop_emqx().
 
 init_per_testcase(_TC, Config) ->
-    ok = emqx_common_test_helpers:ensure_quic_listener(mqtt, 14567),
+    ok = emqtt_test_lib:ensure_quic_listener(mqtt, 14567),
     Config.
 
 end_per_testcase(TC, _Config)
@@ -405,11 +404,6 @@ test_reconnect_immediate_retry(Config) ->
                   {3, {ok, _}},
                   {4, {ok, _}}], ?COLLECT_ASYNC_RESULT(C)),
 
-    ok = emqtt:disconnect(C).
-
-t_ws_connect(_) ->
-    {ok, C} = emqtt:start_link([{clean_start, true}, {host,"127.0.0.1"}, {port, 8083}]),
-    {ok, _} = emqtt:ws_connect(C),
     ok = emqtt:disconnect(C).
 
 t_subscribe(Config) ->

--- a/test/emqtt_connect_SUITE.erl
+++ b/test/emqtt_connect_SUITE.erl
@@ -1,0 +1,122 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqtt_connect_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include("emqtt.hrl").
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include_lib("common_test/include/ct.hrl").
+
+-define(HOSTS,
+        [{ip4,
+          [
+           <<"127.0.0.1">>,
+           "127.0.0.1",
+           {127, 0, 0, 1}
+          ]},
+         {ip6,
+          [
+           "::1",
+           <<"::1">>,
+           {0, 0, 0, 0, 0, 0, 0, 1}
+          ]}]).
+
+-define(LOOPBACK_IP6, {0, 0, 0, 0, 0, 0, 0, 1}).
+
+-define(PORTS, #{
+                {ip4, connect} =>      {1883,  []},
+                {ip4, ws_connect} =>   {8083,  []},
+                {ip4, quic_connect} => {14567, []},
+                {ip6, connect} =>      {21883, [{tcp_opts, [{tcp_module, inet6_tcp}]}]},
+                {ip6, ws_connect} =>   {28083,
+                                        [{ws_transport_options, [{tcp_module, inet6_tcp}]},
+                                         {ws_headers, [{<<"host">>, <<"[::1]:28083">>}]}
+                                        ]},
+                {ip6, quic_connect} => {34567, []}
+               }).
+
+all() ->
+    [ {group, ip6}
+    , {group, ip4}
+    ].
+
+
+connect_groups() -> [
+                     {group, connect},
+                     {group, ws_connect},
+                     {group, quic_connect}
+                    ].
+
+groups() ->
+    [{ip6, [], connect_groups()},
+     {ip4, [], connect_groups()},
+     {connect, [], [t_connect]},
+     {ws_connect, [], [t_connect]},
+     {quic_connect, [], [t_connect]}].
+
+suite() ->
+    [{timetrap, {seconds, 15}}].
+
+init_per_suite(Config) ->
+    ok = emqtt_test_lib:start_emqx(),
+    Config.
+
+end_per_suite(_Config) ->
+    emqtt_test_lib:stop_emqx().
+
+init_per_group(ip4, Config) ->
+    [{ip_type, ip4} | Config];
+init_per_group(ip6, Config) ->
+    case os:getenv("CI") of
+        false ->
+            ok = emqtt_test_lib:ensure_listener(tcp, mqtt_ip6, ?LOOPBACK_IP6, 21883),
+            ok = emqtt_test_lib:ensure_listener(ws, mqtt_ip6, ?LOOPBACK_IP6, 28083),
+            ok = emqtt_test_lib:ensure_listener(quic, mqtt_ip6, ?LOOPBACK_IP6, 34567),
+            [{ip_type, ip6} | Config];
+        _ ->
+            {skip, "Github runners do not support ipv6"}
+    end;
+init_per_group(connect, Config) ->
+    [{conn_fun, connect} | Config];
+init_per_group(ws_connect, Config) ->
+    [{conn_fun, ws_connect} | Config];
+init_per_group(quic_connect, Config) ->
+    [{conn_fun, quic_connect} | Config].
+
+end_per_group(_, Config) ->
+    Config.
+
+t_connect(Config) ->
+    IpType = ?config(ip_type, Config),
+    ConnFun = ?config(conn_fun, Config),
+    Hosts = ?config(IpType, ?HOSTS),
+    {Port, Opts} = maps:get({IpType, ConnFun}, ?PORTS),
+    lists:foreach(
+      fun(Host) ->
+        ct:pal("Connecting to ~p:~p via ~p", [Host, Port, ConnFun]),
+        {ok, C} = emqtt:start_link([{host, Host}, {port, Port}] ++ Opts),
+        {ok, _} = emqtt:ConnFun(C),
+        ct:pal("Connected to ~p:~p via ~p", [Host, Port, ConnFun]),
+        ok= emqtt:disconnect(C)
+      end,
+      Hosts).
+
+

--- a/test/emqtt_frame_SUITE.erl
+++ b/test/emqtt_frame_SUITE.erl
@@ -16,8 +16,8 @@
 
 -module(emqtt_frame_SUITE).
 
--compile(export_all).
 -compile(nowarn_export_all).
+-compile(export_all).
 
 -include("emqtt.hrl").
 -include_lib("proper/include/proper.hrl").

--- a/test/emqtt_props_SUITE.erl
+++ b/test/emqtt_props_SUITE.erl
@@ -16,13 +16,13 @@
 
 -module(emqtt_props_SUITE).
 
--compile(export_all).
 -compile(nowarn_export_all).
+-compile(export_all).
 
 -include("emqtt.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_common_test_helpers:all(?MODULE).
+all() -> emqtt_test_lib:all(?MODULE).
 
 init_per_suite(Config) ->
     code:add_patha(filename:join(code:lib_dir(emqx), "ebin/")),

--- a/test/emqtt_quic_SUITE.erl
+++ b/test/emqtt_quic_SUITE.erl
@@ -15,8 +15,8 @@
 %%--------------------------------------------------------------------
 -module(emqtt_quic_SUITE).
 
--compile(export_all).
 -compile(nowarn_export_all).
+-compile(export_all).
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
@@ -952,8 +952,7 @@ recv_pub(Count, Acc) ->
     end.
 
 all_tc() ->
-    code:add_patha(filename:join(code:lib_dir(emqx), "ebin/")),
-    emqx_common_test_helpers:all(?MODULE).
+    emqtt_test_lib:all(?MODULE).
 
 -spec calc_qos(0|1|2, 0|1|2) -> 0|1|2.
 calc_qos(PubQos, SubQos)->
@@ -976,4 +975,4 @@ calc_pkt_id(2, Id)->
 start_emqx_quic(UdpPort) ->
     emqtt_test_lib:start_emqx(),
     application:ensure_all_started(quicer),
-    ok = emqx_common_test_helpers:ensure_quic_listener(mqtt, UdpPort).
+    ok = emqtt_test_lib:ensure_quic_listener(mqtt, UdpPort).

--- a/test/emqtt_sock_SUITE.erl
+++ b/test/emqtt_sock_SUITE.erl
@@ -16,13 +16,13 @@
 
 -module(emqtt_sock_SUITE).
 
--compile(export_all).
 -compile(nowarn_export_all).
+-compile(export_all).
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 
-all() -> emqx_common_test_helpers:all(?MODULE) ++ [{group, all}].
+all() -> emqtt_test_lib:all(?MODULE) ++ [{group, all}].
 
 groups() ->
     [ {all, [ {group, unknown_ca}


### PR DESCRIPTION
Also
* fixes a bug that `ws_connect` does not actually handle `inet:ip_address()` hosts.
* fixes and clarifies ipv6 connection process (also was broken for ws).