### PR TITLE
fix(ssl): correctly handle ssl error events

### DIFF
--- a/src/emqtt_internal.hrl
+++ b/src/emqtt_internal.hrl
@@ -1,0 +1,17 @@
+%%-------------------------------------------------------------------------
+%% Copyright (c) 2020-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%-------------------------------------------------------------------------
+
+-record(ssl_socket, {tcp, ssl}).

--- a/src/emqtt_sock.erl
+++ b/src/emqtt_sock.erl
@@ -27,7 +27,7 @@
         , getstat/2
         ]).
 
--record(ssl_socket, {tcp, ssl}).
+-include("emqtt_internal.hrl").
 
 -type(socket() :: inet:socket() | #ssl_socket{}).
 

--- a/test/emqtt_SUITE.erl
+++ b/test/emqtt_SUITE.erl
@@ -91,7 +91,8 @@ groups() ->
        t_stop,
        t_pause_resume,
        t_init,
-       t_connected]},
+       t_connected,
+       t_ssl_error]},
     {mqttv3,[],
       [basic_test_v3]},
     {mqttv4, [],
@@ -147,7 +148,7 @@ init_per_group(quic, Config) ->
 init_per_group(_, Config) ->
     case lists:keyfind(conn_fun, 1, Config) of
         false ->
-            merge_config(Config, [{port, 1883}, {conn_fun, connect}]);
+            merge_config(Config, [{port, 1883}, {ssl_port, 8883}, {conn_fun, connect}]);
         _ ->
             Config
     end.
@@ -244,6 +245,30 @@ t_reconnect_disabled(Config) ->
     after 500 ->
             ct:fail(conn_still_alive)
     end.
+
+t_ssl_error(Config) ->
+    ct:timetrap({seconds, 1}),
+    Port = proplists:get_value(ssl_port, Config, 8883),
+    DataDir = cert_dir(Config),
+    emqtt_test_lib:gen_ca(DataDir, "ca"),
+    emqtt_test_lib:gen_ca(DataDir, "ca2"),
+    emqtt_test_lib:gen_host_cert("server", "ca", DataDir, true),
+    emqtt_test_lib:gen_host_cert("client", "ca2", DataDir, true),
+    emqtt_test_lib:set_ssl_options(<<"ssl:default">>,
+                                   #{ verify => verify_peer
+                                    , cacertfile => emqtt_test_lib:ca_cert_name(DataDir, "ca")
+                                    , certfile => emqtt_test_lib:cert_name(DataDir, "server")
+                                    , keyfile => emqtt_test_lib:key_name(DataDir, "server")
+                                    }),
+    process_flag(trap_exit, true),
+    {ok, C} = emqtt:start_link([{port, Port},
+                                {ssl, true},
+                                {ssl_opts, [ {certfile, emqtt_test_lib:cert_name(DataDir, "client")}
+                                           , {keyfile, emqtt_test_lib:key_name(DataDir, "client")}
+                                           ]}
+                               ]),
+    {error, {{shutdown, {tls_alert, {unknown_ca, _}}}, _}} = emqtt:connect(C),
+    ok.
 
 t_reconnect_enabled(Config) ->
     ConnFun = ?config(conn_fun, Config),
@@ -1327,3 +1352,9 @@ retry_if_errors(Errors, Fun) ->
         false ->
             E
     end.
+
+test_dir(Config) ->
+    filename:dirname(filename:dirname(proplists:get_value(data_dir, Config))).
+
+cert_dir(Config) ->
+    filename:join([test_dir(Config), "certs"]).

--- a/test/emqtt_test_lib.erl
+++ b/test/emqtt_test_lib.erl
@@ -32,6 +32,7 @@
         , ca_cert_name/2
         , key_name/2
         , cert_name/2
+        , set_ssl_options/2
         ]
        ).
 
@@ -206,3 +207,8 @@ maybe_wildcard(Str, true) ->
     "*."++Str;
 maybe_wildcard(Str, false) ->
     Str.
+
+set_ssl_options(ListenerId, Opts) ->
+    {ok, #{type := Type, name := Name}} = emqx_listeners:parse_listener_id(ListenerId),
+    emqx_config:put_listener_conf(Type, Name, [ssl_options], Opts),
+    ok = emqx_listeners:restart_listener(ListenerId).


### PR DESCRIPTION
`emqx_sock` defined an internal record for storing both the tcp and ssl socket ports.  However, when we have a TLS error such as `bad_certificate`, `ssl` sends a message containing the inner SSL socket, not this internal emqtt record, and there were missing clauses to handle that.

This caused `emqtt` to:
i) Hang indefinitely if `connect_timeout` is not specified; ii) Fail with `{error, connack_timeout}` if `connect_timeout` is a finite value.