### PR TITLE
upgrade(appup): add emqtt_cli to please emqx appup check

### DIFF
--- a/src/emqtt.appup.src
+++ b/src/emqtt.appup.src
@@ -1,30 +1,36 @@
 %% -*-: erlang -*-
 {"1.2.3.2",
   [ {"1.2.3.1", [
-     {load_module, emqtt_sock, brutal_purge, soft_purge, []}
+     {load_module, emqtt_sock, brutal_purge, soft_purge, []},
+     {load_module, emqtt_cli, brutal_purge, soft_purge, []}
     ]},
     {"1.2.3", [
      {load_module, emqtt, brutal_purge, soft_purge, []},
      {load_module, emqtt_frame, brutal_purge, soft_purge, []},
-     {load_module, emqtt_sock, brutal_purge, soft_purge, []}
+     {load_module, emqtt_sock, brutal_purge, soft_purge, []},
+     {load_module, emqtt_cli, brutal_purge, soft_purge, []}
     ]},
    {<<"1.2.[0-2]">>, [
      {load_module, emqtt_sock, brutal_purge, soft_purge, []},
-     {load_module, emqtt, brutal_purge, soft_purge, []}
+     {load_module, emqtt, brutal_purge, soft_purge, []},
+     {load_module, emqtt_cli, brutal_purge, soft_purge, []}
     ]}
   ],
   [
    {"1.2.3.1", [
-     {load_module, emqtt_sock, brutal_purge, soft_purge, []}
+     {load_module, emqtt_sock, brutal_purge, soft_purge, []},
+     {load_module, emqtt_cli, brutal_purge, soft_purge,[]}
     ]},
    {"1.2.3", [
      {load_module, emqtt, brutal_purge, soft_purge, []},
      {load_module, emqtt_frame, brutal_purge, soft_purge, []},
-     {load_module, emqtt_sock, brutal_purge, soft_purge, []}
+     {load_module, emqtt_sock, brutal_purge, soft_purge, []},
+     {load_module, emqtt_cli, brutal_purge, soft_purge, []}
     ]},
    {<<"1.2.[0-2]">>, [
      {load_module, emqtt_sock, brutal_purge, soft_purge, []},
-     {load_module, emqtt, brutal_purge, soft_purge, []}
+     {load_module, emqtt, brutal_purge, soft_purge, []},
+     {load_module, emqtt_cli, brutal_purge, soft_purge, []}
     ]}
   ]
 }.


### PR DESCRIPTION
emqtt_cli is not in use as library but EMQX appup check wants it otherwise:

```
ERROR: Appup file for 'emqtt' is not complete.
ERROR: Missing:#{down =>
                          [{"1.2.3.1",[{load_module,emqtt_cli,brutal_purge,soft_purge,[]}]},
                           {"1.2.3",[{load_module,emqtt_cli,brutal_purge,soft_purge,[]}]},
                           {<<"1.2.[0-2]">>,[{load_module,emqtt_cli,brutal_purge,soft_purge,[]}]}],
                      up =>
                          [{"1.2.3.1",[{load_module,emqtt_cli,brutal_purge,soft_purge,[]}]},
                           {"1.2.3",[{load_module,emqtt_cli,brutal_purge,soft_purge,[]}]},
                           {<<"1.2.[0-2]">>,
                            [{load_module,emqtt_cli,brutal_purge,soft_purge,[]}]}]}
ERROR: Incomplete appups found. Please inspect the output for more details.
```