### PR TITLE
Remove maybe type

### DIFF
--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -171,7 +171,6 @@
                 | {properties, properties()}
                 | {nst,  binary()}).
 
--type(maybe(T) :: undefined | T).
 -type(topic() :: binary()).
 -type(payload() :: iodata()).
 -type(packet_id() :: 0..16#FFFF).
@@ -223,12 +222,12 @@
           bridge_mode     :: boolean(),
           clientid        :: binary(),
           clean_start     :: boolean(),
-          username        :: maybe(binary()),
+          username        :: binary() | undefined,
           password        :: function(),
           proto_ver       :: version(),
           proto_name      :: iodata(),
           keepalive       :: non_neg_integer(),
-          keepalive_timer :: maybe(timer:tref()),
+          keepalive_timer :: timer:tref() | undefined,
           force_ping      :: boolean(),
           paused          :: boolean(),
           will_flag       :: boolean(),
@@ -242,9 +241,9 @@
           awaiting_rel    :: map(),
           auto_ack        :: boolean(),
           ack_timeout     :: pos_integer(),
-          ack_timer       :: maybe(timer:tref()),
+          ack_timer       :: timer:tref() | undefined,
           retry_interval  :: pos_integer(),
-          retry_timer     :: maybe(timer:tref()),
+          retry_timer     :: timer:tref() | undefined,
           session_present :: boolean(),
           last_packet_id  :: packet_id(),
           low_mem         :: boolean(),


### PR DESCRIPTION
Since OTP 25, the EEP-49 _maybe_expr_ feature was introduced. The `maybe` is now a keyword.