### PR TITLE
Use required cowlib version 2.12.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
             warn_obsolete_guard
            ]}.
 
-{deps, [{cowlib, "2.11.0"},
+{deps, [{cowlib, "2.12.1"},
         {gun, {git, "https://github.com/emqx/gun", {tag, "1.3.7"}}},
         {getopt, "1.0.2"}
        ]}.


### PR DESCRIPTION
Aims to resolve this error when compiling emqtt:
![image](https://github.com/emqx/emqtt/assets/50356453/a37ab524-4208-4f73-915a-e0b4c1075921)
