### PR TITLE
ws_transport_options inserted at wrong level - WSS fails on non-443 TLS ports

### DIFF
--- a/src/emqtt_ws.erl
+++ b/src/emqtt_ws.erl
@@ -42,8 +42,8 @@ connect(Host0, Port, Opts, Timeout) ->
     TransportOptions = proplists:get_value(ws_transport_options, Opts, []),
     TransportOpts = maps:from_list(TransportOptions),
     DefaultOpts = #{connect_timeout => Timeout,
-                       retry => 3,
-                       retry_timeout => 30000},
+                 retry => 3,
+                 retry_timeout => 30000},
     ConnOpts = maps:merge(TransportOpts,DefaultOpts),
     case gun:open(Host1, Port, ConnOpts) of
         {ok, ConnPid} ->

--- a/src/emqtt_ws.erl
+++ b/src/emqtt_ws.erl
@@ -40,11 +40,11 @@ connect(Host0, Port, Opts, Timeout) ->
     {ok, _} = application:ensure_all_started(gun),
     %% 1. open connection
     TransportOptions = proplists:get_value(ws_transport_options, Opts, []),
-    ConnOpts = #{connect_timeout => Timeout,
-                 retry => 3,
-                 retry_timeout => 30000,
-                 transport_opts => TransportOptions
-                },
+    TransportOpts = maps:from_list(TransportOptions),
+    DefaultOpts = #{connect_timeout => Timeout,
+                       retry => 3,
+                       retry_timeout => 30000},
+    ConnOpts = maps:merge(TransportOpts,DefaultOpts),
     case gun:open(Host1, Port, ConnOpts) of
         {ok, ConnPid} ->
             {ok, _} = gun:await_up(ConnPid, Timeout),


### PR DESCRIPTION
In order for wss to work, the contents of ws_transport_options needs to be at the same level as other ConnOpts.

This is required because gun requires two overrides for any non-standard TLS port:
```
{ ws_transport_options, [
                            {transport, tls},
                            {protocols,[http]}
                        ]}
```

The first option is required to specify tls (obviously) since gun will only enable tls on port 443 due to this code in gun.erl:
```
default_transport(443) -> tls;
default_transport(_) -> tcp.

```
Any non-443 SSL connection would then require the "{transport, tls}" option added to ws_transport_options.

The second option is required because gun defaults to http2, which then fails.   Reducing the protocols to just http allows tls to succeed and thus wss will succeed.

One or both of these may become unnecessary in future versions of gun (although I did test up to the current version and both are still issues), however being able to pass correct transport options to ConnOpts in the websocket connection will, no doubt, remain important regardless.