### PR TITLE
fix(emqtt_sock): fix a race condition during ssl upgrade

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -25,6 +25,8 @@
             [ {meck, "0.9.2"}
             , {emqx, {git_subdir, "https://github.com/emqx/emqx", {branch, "master"}, "apps/emqx"}}
             , {emqx_limiter, {git_subdir, "https://github.com/emqx/emqx", {branch, "master"}, "apps/emqx/src/emqx_limiter"}}
+            , {emqx_durable_storage, {git_subdir, "https://github.com/emqx/emqx", {branch, "master"}, "apps/emqx_durable_storage"}}
+            , {emqx_utils, {git_subdir, "https://github.com/emqx/emqx", {branch, "master"}, "apps/emqx_utils"}}
             , {proper, "1.4.0"}
             ]},
          {erl_opts, [debug_info]},

--- a/src/emqtt_sock.erl
+++ b/src/emqtt_sock.erl
@@ -65,9 +65,9 @@ ssl_upgrade(Host, Sock, SslOpts, Timeout) ->
     SslOpts4 = apply_host_check_fun(SslOpts3),
     case ssl:connect(Sock, SslOpts4, Timeout) of
         {ok, SslSock} ->
-            ok = ssl:controlling_process(SslSock, self()),
             {ok, #ssl_socket{tcp = Sock, ssl = SslSock}};
-        {error, Reason} -> {error, Reason}
+        {error, Reason} ->
+            {error, Reason}
     end.
 
 -spec(send(socket(), iodata()) -> ok | {error, einval | closed}).

--- a/test/emqtt_test_lib.erl
+++ b/test/emqtt_test_lib.erl
@@ -96,16 +96,19 @@ ensure_listener(Type, Name, BindAddr, BindPort) ->
     end.
 
 listener_conf(quic) ->
-    #{
-      certfile => filename:join(code:lib_dir(emqx), "etc/certs/cert.pem"),
+    CertFile = filename:join(code:lib_dir(emqx), "etc/certs/cert.pem"),
+    KeyFile = filename:join(code:lib_dir(emqx), "etc/certs/key.pem"),
+    SslOpts = #{
+      certfile => CertFile,
       ciphers =>
       [
        "TLS_AES_256_GCM_SHA384",
        "TLS_AES_128_GCM_SHA256",
        "TLS_CHACHA20_POLY1305_SHA256"
       ],
-      keyfile => filename:join(code:lib_dir(emqx), "etc/certs/key.pem")
-     };
+      keyfile => KeyFile
+     },
+    #{ssl_options => SslOpts};
 listener_conf(ws) ->
     #{
       websocket =>


### PR DESCRIPTION
There is no need to call `ssl:controlling_process` to `self()` after ssl upgrade.
The socket is owned by `self()` already.

Also refined the return value for `connect` call in case `shutdown` happens while waiting for CONNACK.
