### PR TITLE
feat: support OTP 26

### DIFF
--- a/.github/workflows/run_test_case.yaml
+++ b/.github/workflows/run_test_case.yaml
@@ -19,8 +19,7 @@ jobs:
                 docker_image:
                   - "ghcr.io/emqx/emqx-builder/5.0-26:1.13.4-24.3.4.2-1-ubuntu20.04"
                   - "ghcr.io/emqx/emqx-builder/5.1-4:1.14.5-25.3.2-2-ubuntu20.04"
-                 # TODO: enable this line after port_command is fixed
-                 #- "public.ecr.aws/docker/library/erlang:26"
+                  - "public.ecr.aws/docker/library/erlang:26"
 
         steps:
         - name: Checkout


### PR DESCRIPTION
Similar to #196, but maintains compatibility with OTP25. ~Based on the implementation that RabbitMQ used in https://github.com/rabbitmq/rabbitmq-server/pull/7927~