### PR TITLE
1012 add debug log for connect errors and fix dialyzer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+_build/
+rebar.lock
+Dockerfile

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -17,7 +17,8 @@ jobs:
             fail-fast: false
             matrix:
               builder:
-                - 5.0-26
+                - 5.0-26:1.13.4-24.3.4.2-1
+                - 5.1-4:1.14.5-25.3.2-2
               os:
                 - ubuntu20.04
                 - ubuntu18.04
@@ -28,11 +29,6 @@ jobs:
                 # The compiler feature "cxx_std_17" is not known to CXX compiler "GNU" version 4.8.5.
                 # - el7
                 - amzn2
-              otp:
-                - 24.3.4.2-1
-                - 25.1.2-2
-              elixir:
-                - 1.13.4
 
         steps:
         - uses: actions/checkout@v3
@@ -40,7 +36,7 @@ jobs:
             fetch-depth: 0
         - name: build emqx packages
           env:
-            BUILDER_IMAGE: "ghcr.io/emqx/emqx-builder/${{ matrix.builder }}:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os }}"
+            BUILDER_IMAGE: "ghcr.io/emqx/emqx-builder/${{ matrix.builder }}-${{ matrix.os }}"
           # NOTE
           # Doing it manually instead of just setting `container` for the job because of
           # discrepancies in the images' environments affecting even basic things like

--- a/.github/workflows/run_static_checks.yaml
+++ b/.github/workflows/run_static_checks.yaml
@@ -1,4 +1,4 @@
-name: Run test case
+name: Run static checks
 
 on:
     push:
@@ -16,7 +16,6 @@ jobs:
         strategy:
             matrix:
                 builder:
-                  - "5.0-26:1.13.4-24.3.4.2-1-ubuntu20.04"
                   - "5.1-4:1.14.5-25.3.2-2-ubuntu20.04"
 
         container: "ghcr.io/emqx/emqx-builder/${{ matrix.builder }}"
@@ -31,17 +30,5 @@ jobs:
         - name: Run tests
           run: |
             set -e
-            make eunit
-            make ct
-            make cover
-            # @TODO rebar3 tar does not include appup of dep apps
-            # make relup-test
-        - uses: actions/upload-artifact@v3
-          if: always()
-          with:
-            name: logs
-            path: _build/test/logs
-        - uses: actions/upload-artifact@v3
-          with:
-            name: cover
-            path: _build/test/cover
+            make xref
+            make dialyzer

--- a/.github/workflows/run_test_case.yaml
+++ b/.github/workflows/run_test_case.yaml
@@ -14,14 +14,13 @@ jobs:
 
         runs-on: ubuntu-latest
         strategy:
+            fail-fast: false
             matrix:
                 docker_image:
                   - "ghcr.io/emqx/emqx-builder/5.0-26:1.13.4-24.3.4.2-1-ubuntu20.04"
                   - "ghcr.io/emqx/emqx-builder/5.1-4:1.14.5-25.3.2-2-ubuntu20.04"
-                  # TODO: after OTP26 is fixed
-                  # - "public.ecr.aws/docker/library/erlang:26"
-
-        container: "${{ matrix.docker_image }}"
+                 # TODO: enable this line after port_command is fixed
+                 #- "public.ecr.aws/docker/library/erlang:26"
 
         steps:
         - name: Checkout
@@ -33,18 +32,20 @@ jobs:
         - name: Run tests
           env:
             DOCKER_IMAGE: "${{ matrix.docker_image }}"
+          shell: bash
           run: |
             set -e
-            if [[ "${DOCKER_IMAGE}" == *emqx-builder* ]]; then
-              export BUILD_WITHOUT_QUIC=0
-            else
-              export BUILD_WITHOUT_QUIC=1
-            fi
-            make eunit
-            make ct
-            make cover
+            docker build -t testimage --build-arg BUILD_FROM=${DOCKER_IMAGE} -f Dockerfile.test .
+            docker network create --ipv6 --subnet 2001:0DB8::/112 testnet
+            docker run -d --net testnet --name testcontainer testimage bash -c "sleep 1800"
+            docker exec testcontainer bash -c 'make eunit'
+            docker exec testcontainer bash -c 'make ct'
+            docker exec testcontainer bash -c 'make cover'
             # @TODO rebar3 tar does not include appup of dep apps
-            # make relup-test
+            # docker exec testcontainer bash -c 'make relup-test'
+            # copy the build dir to host working dir for following build steps
+            docker cp testcontainer:/_w/_build .
+            docker rm -f testcontainer
         - uses: actions/upload-artifact@v3
           if: always()
           with:

--- a/.github/workflows/run_test_case.yaml
+++ b/.github/workflows/run_test_case.yaml
@@ -15,11 +15,13 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                builder:
-                  - "5.0-26:1.13.4-24.3.4.2-1-ubuntu20.04"
-                  - "5.1-4:1.14.5-25.3.2-2-ubuntu20.04"
+                docker_image:
+                  - "ghcr.io/emqx/emqx-builder/5.0-26:1.13.4-24.3.4.2-1-ubuntu20.04"
+                  - "ghcr.io/emqx/emqx-builder/5.1-4:1.14.5-25.3.2-2-ubuntu20.04"
+                  # TODO: after OTP26 is fixed
+                  # - "public.ecr.aws/docker/library/erlang:26"
 
-        container: "ghcr.io/emqx/emqx-builder/${{ matrix.builder }}"
+        container: "${{ matrix.docker_image }}"
 
         steps:
         - name: Checkout
@@ -29,8 +31,15 @@ jobs:
         - name: work around https://github.com/actions/checkout/issues/766
           run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
         - name: Run tests
+          env:
+            DOCKER_IMAGE: "${{ matrix.docker_image }}"
           run: |
             set -e
+            if [[ "${DOCKER_IMAGE}" == *emqx-builder* ]]; then
+              export BUILD_WITHOUT_QUIC=0
+            else
+              export BUILD_WITHOUT_QUIC=1
+            fi
             make eunit
             make ct
             make cover

--- a/.github/workflows/run_test_case.yaml
+++ b/.github/workflows/run_test_case.yaml
@@ -38,6 +38,7 @@ jobs:
           run: |
             set -e
             make dialyzer
+            make xref
             make eunit
             make ct
             make cover

--- a/.github/workflows/run_test_case.yaml
+++ b/.github/workflows/run_test_case.yaml
@@ -37,6 +37,7 @@ jobs:
         - name: Run tests
           run: |
             set -e
+            make dialyzer
             make eunit
             make ct
             make cover

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,9 @@
+ARG BUILD_FROM=public.ecr.aws/docker/library/erlang:26
+FROM ${BUILD_FROM}
+
+ADD . /_w
+
+WORKDIR /_w
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update -y && apt install -y cmake

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ REBAR ?= $(or $(shell which rebar3 2>/dev/null),$(CURDIR)/rebar3)
 
 REBAR_URL := https://github.com/erlang/rebar3/releases/download/3.19.0/rebar3
 
+export REBAR_GIT_CLONE_OPTIONS += --depth=1
+
 all: emqtt
 
 $(REBAR):

--- a/include/emqtt.hrl
+++ b/include/emqtt.hrl
@@ -40,21 +40,6 @@
 
 -define(IS_QOS(I), (I >= ?QOS_0 andalso I =< ?QOS_2)).
 
--define(QOS_I(Name),
-    begin
-        (case Name of
-            ?QOS_0        -> ?QOS_0;
-            qos0          -> ?QOS_0;
-            at_most_once  -> ?QOS_0;
-            ?QOS_1        -> ?QOS_1;
-            qos1          -> ?QOS_1;
-            at_least_once -> ?QOS_1;
-            ?QOS_2        -> ?QOS_2;
-            qos2          -> ?QOS_2;
-            exactly_once  -> ?QOS_2
-        end)
-    end).
-
 -define(IS_QOS_NAME(I),
         (I =:= qos0 orelse I =:= at_most_once orelse
          I =:= qos1 orelse I =:= at_least_once orelse

--- a/src/emqtt_frame.erl
+++ b/src/emqtt_frame.erl
@@ -44,7 +44,7 @@
                      max_size => 1..?MAX_PACKET_SIZE,
                      version  => version()}).
 
--opaque(parse_state() :: {none, options()} | cont_fun()).
+-type(parse_state() :: {none, options()} | cont_fun()).
 
 -type(parse_result() :: {more, cont_fun()}
                       | {ok, #mqtt_packet{}, binary(), parse_state()}).
@@ -66,11 +66,11 @@
 %% Init Parse State
 %%--------------------------------------------------------------------
 
--spec(initial_parse_state() -> {none, options()}).
+-spec(initial_parse_state() -> parse_state()).
 initial_parse_state() ->
     initial_parse_state(#{}).
 
--spec(initial_parse_state(options()) -> {none, options()}).
+-spec(initial_parse_state(options()) -> parse_state()).
 initial_parse_state(Options) when is_map(Options) ->
     ?none(merge_opts(Options)).
 
@@ -524,8 +524,8 @@ serialize_variable(#mqtt_packet_connect{
                   serialize_binary_data(WillPayload)];
          false -> <<>>
      end,
-     serialize_utf8_string(Username, true),
-     serialize_utf8_string(Password, true)];
+     serialize_utf8_string(Username, <<>>),
+     serialize_utf8_string(Password, <<>>)];
 
 serialize_variable(#mqtt_packet_connack{ack_flags   = AckFlags,
                                         reason_code = ReasonCode,
@@ -702,11 +702,9 @@ serialize_utf8_pair({Name, Value}) ->
 serialize_binary_data(Bin) ->
     [<<(byte_size(Bin)):16/big-unsigned-integer>>, Bin].
 
-serialize_utf8_string(undefined, false) ->
-    error(utf8_string_undefined);
-serialize_utf8_string(undefined, true) ->
-    <<>>;
-serialize_utf8_string(String, _AllowNull) ->
+serialize_utf8_string(undefined, DefaultValue) ->
+    DefaultValue;
+serialize_utf8_string(String, _DefaultValue) ->
     serialize_utf8_string(String).
 
 serialize_utf8_string(String) ->

--- a/src/emqtt_sock.erl
+++ b/src/emqtt_sock.erl
@@ -102,7 +102,7 @@ close(Sock) when is_port(Sock) ->
 close(#ssl_socket{ssl = SslSock}) ->
     ssl:close(SslSock).
 
--spec(setopts(socket(), [gen_tcp:option() | ssl:socketoption()]) -> ok).
+-spec(setopts(socket(), [gen_tcp:option() | ssl:socketoption()]) -> ok | {error, any()}).
 setopts(Sock, Opts) when is_port(Sock) ->
     inet:setopts(Sock, Opts);
 setopts(#ssl_socket{ssl = SslSock}, Opts) ->

--- a/src/emqtt_ws.erl
+++ b/src/emqtt_ws.erl
@@ -40,11 +40,11 @@ connect(Host0, Port, Opts, Timeout) ->
     {ok, _} = application:ensure_all_started(gun),
     %% 1. open connection
     TransportOptions = proplists:get_value(ws_transport_options, Opts, []),
-    TransportOpts = maps:from_list(TransportOptions),
+    TransportOpts = #{transport_opts => TransportOptions},
     DefaultOpts = #{connect_timeout => Timeout,
                  retry => 3,
                  retry_timeout => 30000},
-    ConnOpts = maps:merge(TransportOpts,DefaultOpts),
+    ConnOpts = maps:merge(TransportOpts, DefaultOpts),
     case gun:open(Host1, Port, ConnOpts) of
         {ok, ConnPid} ->
             {ok, _} = gun:await_up(ConnPid, Timeout),

--- a/test/emqtt_quic_SUITE.erl
+++ b/test/emqtt_quic_SUITE.erl
@@ -15,16 +15,18 @@
 %%--------------------------------------------------------------------
 -module(emqtt_quic_SUITE).
 
+
 -compile(nowarn_export_all).
 -compile(export_all).
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
--include_lib("quicer/include/quicer.hrl").
 
 suite() ->
     [{timetrap, {seconds, 30}}].
 
+-ifndef(BUILD_WITHOUT_QUIC).
+-include_lib("quicer/include/quicer.hrl").
 all() ->
     [
      {group, mstream},
@@ -979,3 +981,9 @@ start_emqx_quic(UdpPort) ->
     emqtt_test_lib:start_emqx(),
     application:ensure_all_started(quicer),
     ok = emqtt_test_lib:ensure_quic_listener(mqtt, UdpPort).
+
+-else.
+
+all() ->
+    [].
+-endif. %% BUILD_WITHOUT_QUIC

--- a/test/emqtt_test_lib.erl
+++ b/test/emqtt_test_lib.erl
@@ -22,6 +22,7 @@
         , ensure_listener/4
         , ensure_quic_listener/2
         , all/1
+        , has_quic/0
         ]).
 
 %% TLS helpers
@@ -70,7 +71,12 @@ compile_emqx_test_module(M) ->
 
 -spec ensure_quic_listener(atom(), inet:port_number()) -> ok.
 ensure_quic_listener(Name, BindPort) ->
-    ok = ensure_listener(quic, Name, {0, 0, 0, 0}, BindPort).
+    case has_quic() of
+        true ->
+            ok = ensure_listener(quic, Name, {0, 0, 0, 0}, BindPort);
+        _ ->
+            ok
+    end.
 
 -spec ensure_listener(atom(), atom(), inet:ip_address(), inet:port_number()) -> ok.
 ensure_listener(Type, Name, BindAddr, BindPort) ->
@@ -215,3 +221,6 @@ set_ssl_options(ListenerId, Opts) ->
     {ok, #{type := Type, name := Name}} = emqx_listeners:parse_listener_id(ListenerId),
     emqx_config:put_listener_conf(Type, Name, [ssl_options], Opts),
     ok = emqx_listeners:restart_listener(ListenerId).
+
+has_quic() ->
+    false =:= os:getenv("BUILD_WITHOUT_QUIC").


### PR DESCRIPTION
There is a race condition (the cause of which is yet to be identified):

When TLS alert such as server-raise alert "certificate revoked", there is a chance for the client side ssl:connect call to return ok.
But right after this, if it tries to call setopts, {error, einval} is returned, then if it tries to send data {error, closed} is returned.

This makes the initial CONNECT packet send error to cause a crash from time to time.

This PR is to turn the {error, Reason} return into a shutdown reason, so it will not cause a gen_statem crash.
Also added a debug level log in case the send call returned error. 