### PR TITLE
Fix wss options

### DIFF
--- a/changlog.md
+++ b/changlog.md
@@ -1,13 +1,45 @@
+# 1.9.1
+
+- Removed 'maybe' type.
+- Fix websocket transport options.
+- Support OTP 26.
+- Drop `reuse_sessions` and `secure_renegotiate` options when TLS 1.3 is the only version in use.
+
+# 1.9.0
+
+- Upgrade `quicer` lib
+
+# 1.8.7
+
+- Fix a race-condition caused crash when changing control process after SSL upgrade.
+  The race-condition is from OTP's `ssl` lib, this fix only avoids `emqtt` process to crash.
+
+# 1.8.6
+
+- Sensitive data obfuscation in debug logs.
+
+# 1.8.5
+
+- Fix ssl error messages handeling.
+
+# 1.8.4
+
+- Support MacOS build for QUIC
+
+# 1.8.3
+
+- Support `binary()` hostname.
+
+# 1.8.0-1.8.2
+
+- Support QUIC Multi-stream
+
 # 1.7.0
 
-## Enhancements
-
-* Hide password in an anonymous function to prevent it from leaking into the (crash) logs [#168](https://github.com/emqx/emqtt/pull/168)
-* Added `publish_async` APIs to support asynchronous publishing. [#165](https://github.com/emqx/emqtt/pull/165)
+- Hide password in an anonymous function to prevent it from leaking into the (crash) logs [#168](https://github.com/emqx/emqtt/pull/168)
+- Added `publish_async` APIs to support asynchronous publishing. [#165](https://github.com/emqx/emqtt/pull/165)
   Note that an incompatible update has been included, where the return format
   of the `publish` function has been changed to `ok | {ok, publish_reply()} | {error, Reason}`
 
-## Bug fixes
-
-* Fixed inflight message retry after reconnect [#166](https://github.com/emqx/emqtt/pull/166)
-* Respect connect_timeout [#169](https://github.com/emqx/emqtt/pull/169)
+- Fixed inflight message retry after reconnect [#166](https://github.com/emqx/emqtt/pull/166)
+- Respect connect_timeout [#169](https://github.com/emqx/emqtt/pull/169)

--- a/test/emqtt_connect_SUITE.erl
+++ b/test/emqtt_connect_SUITE.erl
@@ -39,7 +39,7 @@
                 {ip4, quic_connect} => {14567, []},
                 {ip6, connect} =>      {21883, [{tcp_opts, [{tcp_module, inet6_tcp}]}]},
                 {ip6, ws_connect} =>   {28083,
-                                        [{ws_transport_options, [{tcp_module, inet6_tcp}]},
+                                        [{ws_transport_options, [{protocols, [http]}, {tcp_opts, [inet6]}]},
                                          {ws_headers, [{<<"host">>, <<"[::1]:28083">>}]}
                                         ]},
                 {ip6, quic_connect} => {34567, []}


### PR DESCRIPTION
This is a follow up fix for https://github.com/emqx/emqtt/pull/213

Group tcp/ssl options as the latest version gun does:
https://github.com/ninenines/gun/blob/48eefebff2d0412bf6fe8a53182ef88a443b293f/src/gun.erl#L152-L157

However, since we are still on gun-1.3, it has to be translated before passed down.