### PR TITLE
feat(opt): allow external wrapped secrets as passwords

### DIFF
--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -151,7 +151,7 @@
                 | {clientid, iodata()}
                 | {clean_start, boolean()}
                 | {username, iodata()}
-                | {password, iodata()}
+                | {password, iodata() | emqtt_secret:t(binary())}
                 | {proto_ver, v3 | v4 | v5}
                 | {keepalive, non_neg_integer()}
                 | {max_inflight, pos_integer()}
@@ -225,7 +225,7 @@
           clientid        :: binary(),
           clean_start     :: boolean(),
           username        :: binary() | undefined,
-          password        :: undefined | function(),
+          password        :: undefined | emqtt_secret:t(binary()),
           proto_ver       :: version(),
           proto_name      :: iodata(),
           keepalive       :: non_neg_integer(),
@@ -804,6 +804,8 @@ init([{clean_start, CleanStart} | Opts], State) when is_boolean(CleanStart) ->
     init(Opts, State#state{clean_start = CleanStart});
 init([{username, Username} | Opts], State) ->
     init(Opts, State#state{username = iolist_to_binary(Username)});
+init([{password, Secret} | Opts], State) when is_function(Secret, 0) ->
+    init(Opts, State#state{password = Secret});
 init([{password, Password} | Opts], State) ->
     init(Opts, State#state{password = emqtt_secret:wrap(iolist_to_binary(Password))});
 init([{keepalive, Secs} | Opts], State) ->

--- a/src/emqtt_secret.erl
+++ b/src/emqtt_secret.erl
@@ -21,15 +21,21 @@
 %% API:
 -export([wrap/1, unwrap/1]).
 
+-export_type([t/1]).
+
+-type t(T) :: fun(() -> T).
+
 %%================================================================================
 %% API funcions
 %%================================================================================
 
+-spec wrap(T) -> t(T).
 wrap(Term) ->
     fun() ->
         Term
     end.
 
+-spec unwrap(t(T) | T) -> T.
 unwrap(Term) when is_function(Term, 0) ->
     %% Handle potentially nested funs
     unwrap(Term());

--- a/test/emqtt_SUITE.erl
+++ b/test/emqtt_SUITE.erl
@@ -91,6 +91,7 @@ groups() ->
        t_stop,
        t_pause_resume,
        t_init,
+       t_init_external_secret,
        t_connected,
        t_ssl_error_client_reject_server,
        t_ssl_error_server_reject_client]},
@@ -1082,6 +1083,19 @@ t_init(Config) ->
                                  {will_props, #{}}]),
     {ok, _} = emqtt:ConnFun(C3),
     ok = emqtt:disconnect(C3).
+
+t_init_external_secret(Config) ->
+    ConnFun = ?config(conn_fun, Config),
+    Port = ?config(port, Config),
+    Secret = fun() -> <<"password">> end,
+    {ok, C} = emqtt:start_link([{host, {127,0,0,1}},
+                                {port, Port},
+                                {clientid, <<"test">>},
+                                {username, <<"username">>},
+                                {password, Secret},
+                                {proto_ver, v3}]),
+    {ok, _} = emqtt:ConnFun(C),
+    ok = emqtt:disconnect(C).
 
 t_initialized(_) ->
     error('TODO').


### PR DESCRIPTION
By convention, any 0-arity function is considered a wrapped secret.

Part of EMQX-10808.