### PR TITLE
fix: fix type specs and dialyzer checks

### DIFF
--- a/.github/workflows/run_test_case.yaml
+++ b/.github/workflows/run_test_case.yaml
@@ -17,8 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 docker_image:
-                  - "ghcr.io/emqx/emqx-builder/5.1-4:1.14.5-25.3.2-2-ubuntu22.04"
-                  - "ghcr.io/emqx/emqx-builder/5.2-7:1.15.7-26.1.2-1-ubuntu22.04"
+                  - "ghcr.io/emqx/emqx-builder/5.3-13:1.15.7-26.2.5.2-1-ubuntu22.04"
 
         steps:
         - name: Checkout

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ option() = {name, atom()} |
            {port, inet:port_number()} |
            {tcp_opts, [gen_tcp:option()]} |
            {ssl, boolean()} |
-           {ssl_opts, [ssl:ssl_option()]} |
+           {ssl_opts, [ssl:tls_client_option()]} |
            {ws_path, string()} |
            {connect_timeout, pos_integer()} |
            {bridge_mode, boolean()} |

--- a/rebar.config
+++ b/rebar.config
@@ -134,14 +134,13 @@
 
 {xref_checks, [undefined_function_calls]}.
 
-{dialyzer_base_plt_apps,
- [kernel,
-  stdlib,
-  erts,
-  sasl,
-  ssl,
-  syntax_tools,
-  compiler,
-  crypto]}.
+{dialyzer, [
+    {warnings, [unmatched_returns, error_handling]},
+    {plt_location, "."},
+    {plt_prefix, "emqtt_dialyzer"},
+    {plt_apps, all_apps},
+    {statistics, true},
+    {plt_extra_apps, [quicer, getopt]}
+]}.
 
 {project_plugins, [{relup_helper,{git,"https://github.com/emqx/relup_helper", {tag, "2.0.0"}}}]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -43,7 +43,7 @@ NewProfiles = lists:foldl(fun(Key, Acc) ->
 
 NewConfig = lists:keystore(profiles, 1, CONFIG, {profiles, NewProfiles}),
 
-Quicer = {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.0.307"}}},
+Quicer = {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.1.8"}}},
 KillQuicer = fun(C) ->
                 {deps, Deps0} = lists:keyfind(deps, 1, C),
                 {erl_opts, ErlOpts0} = lists:keyfind(erl_opts, 1, C),

--- a/src/emqtt.app.src
+++ b/src/emqtt.app.src
@@ -4,7 +4,7 @@
   {vsn, {cmd, "git describe --tags --always"}},
   {modules, []},
   {registered, []},
-  {applications, [kernel, stdlib]},
+  {applications, [kernel, stdlib, gun]},
   {env, []},
   {licenses, ["Apache-2.0"]},
   {maintainers, ["EMQ X Team <contact@emqx.io>"]},

--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -134,7 +134,7 @@
 
 %% Message handler is a set of callbacks defined to handle MQTT messages
 %% as well as the disconnect event.
--type(msg_handler() :: #{publish => fun((emqx_types:message()) -> any()) | mfas(),
+-type(msg_handler() :: #{publish => fun((_Publish :: map()) -> any()) | mfas(),
                          pubrel => fun((_PubRel :: map()) -> any()) | mfas(),
                          connected => fun((_Properties :: term()) -> any()) | mfas(),
                          disconnected => fun(({reason_code(), _Properties :: term()}) -> any()) | mfas()
@@ -148,7 +148,7 @@
                 | {port, inet:port_number()}
                 | {tcp_opts, [gen_tcp:option()]}
                 | {ssl, boolean()}
-                | {ssl_opts, [ssl:ssl_option()]}
+                | {ssl_opts, [ssl:tls_client_option()]}
                 | {quic_opts, {_, _}}
                 | {ws_path, string()}
                 | {connect_timeout, pos_integer()}

--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -760,7 +760,7 @@ maybe_rand_id(_, ?NO_CLIENT_ID) -> random_client_id();
 maybe_rand_id(_, ID) -> ID.
 
 random_client_id() ->
-    rand:seed(exsplus, erlang:timestamp()),
+    _ = rand:seed(exsplus, erlang:timestamp()),
     I1 = rand:uniform(round(math:pow(2, 48))) - 1,
     I2 = rand:uniform(round(math:pow(2, 32))) - 1,
     {ok, Host} = inet:gethostname(),

--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -980,7 +980,7 @@ initialized({call, From}, {open_connection, emqtt_quic}, #state{sock_opts = Sock
             {stop_and_reply, {shutdown, Error}, {reply, From, Error}}
     end;
 initialized({call, From}, quic_mqtt_connect, #state{socket = {quic, Conn, undefined}} = State) ->
-    {ok, NewCtrlStream} = quicer:start_stream(Conn, [{active, 1}]),
+    {ok, NewCtrlStream} = quicer:start_stream(Conn, #{active => 1}),
     NewSocket = {quic, Conn, NewCtrlStream},
     case mqtt_connect(maybe_update_ctrl_sock(emqtt_quic, maybe_init_quic_state(emqtt_quic, State), NewSocket)) of
         {ok, #state{socket = Via} = NewState} ->

--- a/src/emqtt_cli.erl
+++ b/src/emqtt_cli.erl
@@ -147,8 +147,8 @@ main(_Argv) ->
 
 main(PubSubOrJustConnect, Opts0) ->
     _ = process_flag(trap_exit, true),
-    application:ensure_all_started(quicer),
-    application:ensure_all_started(emqtt),
+    _ = application:ensure_all_started(quicer),
+    _ = application:ensure_all_started(emqtt),
     Print = proplists:get_value(print, Opts0),
     Opts = proplists:delete(print, Opts0),
     NOpts = enrich_opts(parse_cmd_opts(Opts)),
@@ -156,7 +156,7 @@ main(PubSubOrJustConnect, Opts0) ->
         undefined ->
             ok;
         Level ->
-            logger:set_primary_config(level, Level)
+            ok = logger:set_primary_config(level, Level)
     end,
     {ok, Client} = emqtt:start_link(NOpts),
     ConnRet = case {proplists:get_bool(enable_websocket, NOpts),
@@ -181,7 +181,7 @@ main(PubSubOrJustConnect, Opts0) ->
                         #{'Server-Keep-Alive' := I} -> I;
                         _ -> get_value(keepalive, NOpts)
                     end,
-                    timer:send_interval(KeepAlive * 1000, ping),
+                    _ = timer:send_interval(KeepAlive * 1000, ping),
                     receive_loop(Client, Print)
             end;
         {error, Reason} ->
@@ -427,6 +427,7 @@ i(false) -> 0.
 log(Fmt, Args) ->
     io:format("~s " ++ Fmt, [ts() | Args]).
 
+-spec log_halt(_, _) -> no_return().
 log_halt(Fmt, Args) ->
     log(Fmt, Args),
     halt(1).

--- a/src/emqtt_frame.erl
+++ b/src/emqtt_frame.erl
@@ -51,7 +51,18 @@
 
 -type(cont_fun() :: fun((binary()) -> parse_result())).
 
--type(serialize_fun() :: fun((emqx_types:packet()) -> iodata())).
+-type(packet() :: #mqtt_packet_connect{} |
+                  #mqtt_packet_connack{} |
+                  #mqtt_packet_publish{} |
+                  #mqtt_packet_puback{} |
+                  #mqtt_packet_subscribe{} |
+                  #mqtt_packet_suback{} |
+                  #mqtt_packet_unsubscribe{} |
+                  #mqtt_packet_unsuback{} |
+                  #mqtt_packet_disconnect{} |
+                  #mqtt_packet_auth{}).
+
+-type(serialize_fun() :: fun((packet()) -> iodata())).
 
 -define(none(Options), {none, Options}).
 

--- a/src/emqtt_quic_stream.erl
+++ b/src/emqtt_quic_stream.erl
@@ -178,7 +178,7 @@ handle_call(_Stream, _Request, _Opts, S) ->
 
 %%% Internals
 -spec parse(binary(), emqtt_frame:parse_state(), emqtt_quic:mqtt_packets())
-           -> emqtt_frame:parse_res().
+           -> emqtt_frame:parse_result().
 parse(<<>>, PS, Packets) ->
     {keep_state, PS, Packets};
 parse(Bin, PS, Packets) ->

--- a/src/emqtt_quic_stream.erl
+++ b/src/emqtt_quic_stream.erl
@@ -42,7 +42,7 @@
 -define(LOG(Level, Msg, Meta, State),
         ?SLOG(Level, Meta#{msg => Msg, clientid => maps:get(clientid, State)}, #{})).
 
--type cb_ret() :: gen_statem:event_handler_result().
+-type cb_ret() :: gen_statem:handle_event_result().
 -type cb_data() :: emqtt_quic:cb_data().
 
 -spec init_handoff(stream_handle(), #{}, quicer:connection_handle(), #{}) -> cb_ret().
@@ -50,7 +50,7 @@ init_handoff(_Stream, _StreamOpts, _Conn, _Flags) ->
     %% stream owner already set while starts.
     {stop, unimpl}.
 
--spec new_stream(stream_handle(), quicer:new_stream_props(), cb_data()) -> cb_ret().
+-spec new_stream(stream_handle(), quicer:new_stream_props(), connection_handle()) -> cb_ret().
 new_stream(_Stream, #{flags := _Flags, is_orphan := _IsOrphan}, _Conn) ->
     {stop, unimpl}.
 
@@ -62,19 +62,19 @@ peer_accepted(_Stream, undefined, _S) ->
 -spec peer_receive_aborted(stream_handle(), non_neg_integer(), cb_data()) -> cb_ret().
 peer_receive_aborted(Stream, ErrorCode, #{is_unidir := false} = _S) ->
     %% we abort send with same reason
-    quicer:async_shutdown_stream(Stream, ?QUIC_STREAM_SHUTDOWN_FLAG_ABORT, ErrorCode),
+    _ = quicer:async_shutdown_stream(Stream, ?QUIC_STREAM_SHUTDOWN_FLAG_ABORT, ErrorCode),
     keep_state_and_data;
 peer_receive_aborted(Stream, ErrorCode, #{is_unidir := true, is_local := true} = _S) ->
-    quicer:async_shutdown_stream(Stream, ?QUIC_STREAM_SHUTDOWN_FLAG_ABORT, ErrorCode),
+    _ = quicer:async_shutdown_stream(Stream, ?QUIC_STREAM_SHUTDOWN_FLAG_ABORT, ErrorCode),
     keep_state_and_data.
 
 -spec peer_send_aborted(stream_handle(), non_neg_integer(), cb_data()) -> cb_ret().
 peer_send_aborted(Stream, ErrorCode, #{is_unidir := false} = _S) ->
     %% we abort receive with same reason
-    quicer:async_shutdown_stream(Stream, ?QUIC_STREAM_SHUTDOWN_FLAG_ABORT_RECEIVE, ErrorCode),
+    _ = quicer:async_shutdown_stream(Stream, ?QUIC_STREAM_SHUTDOWN_FLAG_ABORT_RECEIVE, ErrorCode),
     keep_state_and_data;
 peer_send_aborted(Stream, ErrorCode, #{is_unidir := true, is_local := false} = _S) ->
-    quicer:async_shutdown_stream(Stream, ?QUIC_STREAM_SHUTDOWN_FLAG_ABORT_RECEIVE, ErrorCode),
+    _ = quicer:async_shutdown_stream(Stream, ?QUIC_STREAM_SHUTDOWN_FLAG_ABORT_RECEIVE, ErrorCode),
     keep_state_and_data.
 
 -spec peer_send_shutdown(stream_handle(), undefined, cb_data()) -> cb_ret().
@@ -133,7 +133,7 @@ handle_stream_data(_Stream, _Bin, _Flags,
 -spec passive(stream_handle(), undefined, cb_data()) -> cb_ret().
 passive(Stream, undefined, _S)->
     %% @TODO Should be called only once during the whole connecion
-    quicer:setopt(Stream, active, true),
+    _ = quicer:setopt(Stream, active, true),
     keep_state_and_data.
 
 -spec stream_closed(stream_handle(), stream_closed_props(), cb_data()) -> cb_ret().
@@ -178,7 +178,7 @@ handle_call(_Stream, _Request, _Opts, S) ->
 
 %%% Internals
 -spec parse(binary(), emqtt_frame:parse_state(), emqtt_quic:mqtt_packets())
-           -> emqtt_frame:parse_result().
+           -> cb_ret().
 parse(<<>>, PS, Packets) ->
     {keep_state, PS, Packets};
 parse(Bin, PS, Packets) ->

--- a/src/emqtt_sock.erl
+++ b/src/emqtt_sock.erl
@@ -33,7 +33,7 @@
 
 -type(sockname() :: {inet:ip_address(), inet:port_number()}).
 
--type(option() :: gen_tcp:connect_option() | {ssl_opts, [ssl:ssl_option()]}).
+-type(option() :: gen_tcp:connect_option() | {ssl_opts, [ssl:tls_client_option()]}).
 
 -export_type([socket/0, option/0]).
 
@@ -111,7 +111,7 @@ close(Sock) when is_port(Sock) ->
 close(#ssl_socket{ssl = SslSock}) ->
     ssl:close(SslSock).
 
--spec(setopts(socket(), [gen_tcp:option() | ssl:socketoption()]) -> ok | {error, any()}).
+-spec(setopts(socket(), [gen_tcp:option() | ssl:tls_client_option()]) -> ok | {error, any()}).
 setopts(Sock, Opts) when is_port(Sock) ->
     inet:setopts(Sock, Opts);
 setopts(#ssl_socket{ssl = SslSock}, Opts) ->


### PR DESCRIPTION
fixes #255 

Still a few dialyzer warnings are left, all related to `quic` calls.