### PR TITLE
241112 reconnect if socket error at wating_for_connack state

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,23 @@
+# 1.13.4
+
+- Handle `tcp_error` and `ssl_error` at `waiting_for_connack` state.
+- Change log level for `reconnect_due_to_connection_error` from `error` to `info`
+- Fix compile warnings on OTP 27.
+
+# 1.13.3
+
+- Fix compile issues on OTP 27.
+
+# 1.13.2
+
+- Support fine-tuneing QUIC transport options.
+
+# 1.13.1
+
+- Support QUIC stream ID.
+- Improve exception context when broker did not assign client ID as expected.
+  Changed `bad_client_id` to `no_client_id_assigned_by_broker` so we know it's broker to blame but not client.
+
 # 1.13.0
 
 - Support Kerberos authentication callbacks.

--- a/include/logger.hrl
+++ b/include/logger.hrl
@@ -21,9 +21,7 @@
 %% check 'allow' here, only evaluate Data and Meta when necessary
     case logger:allow(Level, ?MODULE) of
         true ->
-            logger:log(Level, (Data), (Meta#{ mfa => {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY}
-                                            , line => ?LINE
-            }));
+            logger:log(Level, (Data), (begin Meta end)#{mfa => {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY}, line => ?LINE});
         false ->
             ok
     end).

--- a/test/emqtt_test_lib.erl
+++ b/test/emqtt_test_lib.erl
@@ -95,7 +95,8 @@ ensure_listener(Type, Name, BindAddr, BindPort) ->
                  mountpoint => <<>>,
                  zone => default,
                  proxy_protocol => false,
-                 tcp_options => #{active_n => 100}
+                 tcp_options => #{active_n => 10},
+                 hibernate_after => 5000
                 },
     TypeSpecificConf = listener_conf(Type),
     Conf = maps:merge(BaseConf, TypeSpecificConf),


### PR DESCRIPTION
- prior to this fix, only `tcp_closed` and `ssl_closed` were handled at `waiting_for_connack` state.
- this PR adds the same handling for `tcp_error` and `ssl_error`.
- fixed map literal mutate compile warnings on otp 27