### PR TITLE
241112 reconnect if sending CONNECT returned transport error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,8 @@
 # 1.13.4
 
-- Handle `tcp_error` and `ssl_error` at `waiting_for_connack` state.
-- Change log level for `reconnect_due_to_connection_error` from `error` to `info`
+- Handle CONNECT packet send error asynchronously so to allow a retry.
+- Handle `tcp_error` and `ssl_error` at `waiting_for_connack` state so to allow a retry.
+- Change log level for `reconnect_due_to_connection_error` from `error` to `info`.
 - Fix compile warnings on OTP 27.
 
 # 1.13.3

--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -1558,7 +1558,7 @@ handle_event(info, {Error, Sock, Reason}, _StateName, #state{socket = Sock} = St
     {stop, {shutdown, Reason}, State};
 
 handle_event(info, {ssl_error = Error, SSLSock, Reason}, _StateName, #state{socket = #ssl_socket{ssl = SSLSock}} = State) ->
-    ?LOG(error, "connection_error",
+    ?LOG(error, "TLS connection_error",
          #{error => Error, reason => Reason}, State),
     {stop, {shutdown, Reason}, State};
 

--- a/test/emqtt_SUITE.erl
+++ b/test/emqtt_SUITE.erl
@@ -303,11 +303,8 @@ t_ssl_error_server_reject_client(Config) ->
                                            , {verify, verify_none}
                                            ]}
                                ]),
-    ?assertExit({{shutdown,
-                  {tls_alert,
-                   {unknown_ca,
-                    "TLS client: In state connection received SERVER ALERT: Fatal - Unknown CA\n"}}}, _},
-                emqtt:connect(C)),
+    {error, Reason} = emqtt:connect(C),
+    ?assertMatch({ssl_error, _Sock, {tls_alert, {unknown_ca, _}}}, Reason),
     ok.
 
 t_reconnect_enabled(Config) ->

--- a/test/emqtt_SUITE.erl
+++ b/test/emqtt_SUITE.erl
@@ -301,8 +301,11 @@ t_ssl_error_server_reject_client(Config) ->
                                            , {verify, verify_none}
                                            ]}
                                ]),
-    ?assertMatch({error, {ssl_error, _Sock, {tls_alert, {unknown_ca, _}}}},
-                 emqtt:connect(C)),
+    ?assertExit({{shutdown,
+                  {tls_alert,
+                   {unknown_ca,
+                    "TLS client: In state connection received SERVER ALERT: Fatal - Unknown CA\n"}}}, _},
+                emqtt:connect(C)),
     ok.
 
 t_reconnect_enabled(Config) ->


### PR DESCRIPTION
see also changelog

- if socket error is returend when sending CONNECT, do not stop
  but wait for the socket error event to trigger a retry

- update call ID so the `connect` caller can get a reply later
  if `CONNACK` is received from a new socket

- ignore socket error and close event when at back-off/cool-down
  state (reconnect) because we know it's a stale message.