### PR TITLE
Improve logs and readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,10 +372,12 @@ $ rebar3 compile
 option() = {name, atom()} |
            {owner, pid()} |
            {host, host()} |
+           {hosts, [{host(), inet:port_number()}]} |
            {port, inet:port_number()} |
            {tcp_opts, [gen_tcp:option()]} |
            {ssl, boolean()} |
            {ssl_opts, [ssl:tls_client_option()]} |
+           {quic_opts, {ConnOpts, StreamOpts}} |
            {ws_path, string()} |
            {connect_timeout, pos_integer()} |
            {bridge_mode, boolean()} |
@@ -395,6 +397,9 @@ option() = {name, atom()} |
            {auto_ack, boolean()} |
            {ack_timeout, pos_integer()} |
            {force_ping, boolean()} |
+           {low_mem, boolean()} |
+           {reconnect, infinity | non_neg_integer()} |
+           {reconnect_timeout, pos_integer()} |
            {properties, properties()} |
            {custom_auth_callbacks, map()}
 ```
@@ -527,6 +532,10 @@ Client process will send messages like `{diconnected, ReasonCode, Properties}` t
 
 The host of the MQTT server to be connected. Host can be a hostname or an IP address. Defaults to `localhost`
 
+`{hosts, [{Host, Port}]}`
+
+A list of hosts to connect to. If the connection to the first host fails, the client will try the next host in the list. If the connection to all hosts fails, the client will return an error. Setting this option will override the `host` option.
+
 `{port, Port}`
 
 The port of the MQTT server to be connected. If not given, the default of 1883 for MQTT or 8883 for MQTT over TLS will be used.
@@ -620,6 +629,18 @@ Maximum time to wait for a reply message. Defaults to 30s.
 `{force_ping, boolean()}`
 
 If false (the default), if any other packet is sent during keep alive interval, the ping packet will not be sent this time. If true, the ping packet will be sent every time.
+
+`{low_mem, boolean()}`
+
+If true, the client will try to reduce memory usage by garbage collecting more frequently. Defaults to false.
+
+`{reconnect, infinity | non_neg_integer()}`
+
+The maximum number of reconnection attempts. Defaults to 0, means no reconnection.
+
+`{reconnect_timeout, pos_integer()}`
+
+The time interval between reconnection attempts. Defaults to 5s.
 
 `{properties, Properties}`
 

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ option() = {name, atom()} |
            {tcp_opts, [gen_tcp:option()]} |
            {ssl, boolean()} |
            {ssl_opts, [ssl:tls_client_option()]} |
-           {quic_opts, {ConnOpts, StreamOpts}} |
+           {quic_opts, {quicer:conn_opts(), quicer:stream_opts()}} |
            {ws_path, string()} |
            {connect_timeout, pos_integer()} |
            {bridge_mode, boolean()} |

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+# 1.13.5
+
+- Avoid OTP crash reports by wrapping exit reason in the format `{shutdown,Reason}`.
+- Avoid `badmatch` error when `websocket` connection timeout.
+- Reformat some code for readability.
+- Fix `emqtt` was not trying to reconnect in certain error scenarios.
+- Fix function specs for `emqtt:connect/1` and `emqtt:ws_connect/1`.
+- Add missing opts to `README.md`.
+
 # 1.13.4
 
 - Handle CONNECT packet send error asynchronously so to allow a retry.

--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -1106,7 +1106,7 @@ reconnect(info, {Error, StaleSock, _Reason}, #state{socket = StaleSock}) when ?S
     %% ignore stale socket error events
     keep_state_and_data;
 reconnect(info, {'EXIT', Owner, Reason}, State = #state{owner = Owner}) ->
-    ?LOG(debug, "EXIT_from_owner", #{reason => Reason}, State),
+    ?LOG(debug, "exit_from_owner", #{reason => Reason}, State),
     shutdown({owner, Owner, Reason}, State);
 reconnect(_EventType, _, _State) ->
     {keep_state_and_data, postpone}.
@@ -2221,7 +2221,7 @@ process_incoming(Bytes, Packets, State = #state{parse_state = ParseState, socket
             {keep_state, State#state{parse_state = NParseState}, next_events(Via, Packets)}
     catch
         error:Reason:St ->
-            shutdown({parse_packets_error, Reason, St}, State)
+            maybe_shutdown({parse_packets_error, Reason, St}, State)
     end.
 
 -compile({inline, [next_events/2]}).

--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -396,10 +396,11 @@ with_owner(Options) ->
         undefined -> [{owner, self()} | Options]
     end.
 
--spec(connect(client()) -> {ok, properties()} | {error, term()}).
+-spec(connect(client()) -> {ok, properties() | undefined} | {error, term()}).
 connect(Client) ->
     call(Client, {connect, emqtt_sock}).
 
+-spec(ws_connect(client()) -> {ok, properties() | undefined} | {error, term()}).
 ws_connect(Client) ->
     call(Client, {connect, emqtt_ws}).
 
@@ -1515,7 +1516,7 @@ handle_event(info, {gun_ws, ConnPid, _StreamRef, {binary, Data}},
 
 handle_event(info, {gun_down, ConnPid, _, Reason, _, _},
              _StateName, State = #state{socket = ConnPid}) ->
-    ?LOG(debug, "webSocket_down", #{reason => Reason}, State),
+    ?LOG(debug, "websocket_down", #{reason => Reason}, State),
     {stop, Reason, State};
 
 handle_event(info, {TcpOrSsL, _Sock, Data}, _StateName, State)

--- a/src/emqtt_quic_connection.erl
+++ b/src/emqtt_quic_connection.erl
@@ -59,10 +59,10 @@ init(ConnOpts) when is_map(ConnOpts) ->
 
 -spec closed(connection_handle(), quicer:conn_closed_props(), cb_data()) -> cb_ret().
 closed(_Conn, #{} = _Flags, #{state_name := waiting_for_connack, reconnect := true} =  S) ->
-    ?LOG(error, "QUIC_connection_closed_reconnect", #{}, S),
+    ?LOG(error, "quic_connection_closed_reconnect", #{}, S),
     keep_state_and_data;
 closed(_Conn, #{} = _Flags, #{state_name := _Other} = S)->
-    ?LOG(error, "QUIC_connection_closed", #{}, S),
+    ?LOG(error, "quic_connection_closed", #{}, S),
     %% @TODO why not stop?
     {stop, {shutdown, conn_closed}, S}.
 
@@ -93,7 +93,7 @@ shutdown(Conn, _ErrorCode, #{reconnect := true}) ->
     {keep_state_and_data, {next_event, info, {quic_closed, Conn}}};
 shutdown(Conn, ErrorCode, S) ->
     ok = quicer:async_close_connection(Conn),
-    ?LOG(info, "QUIC_peer_conn_shutdown", #{error_code => ErrorCode}, S),
+    ?LOG(info, "quic_peer_conn_shutdown", #{error_code => ErrorCode}, S),
     %% TCP return {shutdown, closed}
     case ErrorCode of
         success ->
@@ -107,7 +107,7 @@ shutdown(Conn, ErrorCode, S) ->
 -spec transport_shutdown(connection_handle(), quicer:transport_shutdown_props(), cb_data())
                         -> cb_ret().
 transport_shutdown(_C, DownInfo, S) ->
-    ?LOG(error, "QUIC_transport_shutdown", #{down_info => DownInfo}, S),
+    ?LOG(error, "quic_transport_shutdown", #{down_info => DownInfo}, S),
     keep_state_and_data.
 
 -spec peer_address_changed(connection_handle(), quicer:quicer_addr(), cb_data()) -> cb_ret().

--- a/src/emqtt_quic_stream.erl
+++ b/src/emqtt_quic_stream.erl
@@ -87,7 +87,7 @@ send_complete(_Stream, false, _S) ->
     keep_state_and_data;
 send_complete(_Stream, true = _IsCanceled, S) ->
     %% @TODO bump counter
-    ?LOG(error, "QUIC_stream_send_canceled", #{}, S),
+    ?LOG(error, "quic_stream_send_canceled", #{}, S),
     keep_state_and_data.
 
 -spec send_shutdown_complete(stream_handle(), boolean(), cb_data()) -> cb_ret().
@@ -97,13 +97,13 @@ send_shutdown_complete(_Stream, _IsGraceful, _S) ->
 -spec start_completed(stream_handle(), quicer:stream_start_completed_props(), cb_data())
                      -> cb_ret().
 start_completed(_Stream, #{status := success, stream_id := StreamId} = Prop, S) ->
-    ?LOG(debug, "QUIC_stream_start_completed", Prop, S),
+    ?LOG(debug, "quic_stream_start_completed", Prop, S),
     {ok, S#{stream_id => StreamId}};
 start_completed(_Stream, #{status := stream_limit_reached, stream_id := _StreamId} = Prop, S) ->
-    ?LOG(error, "QUIC_stream_start_failed", Prop, S),
+    ?LOG(error, "quic_stream_start_failed", Prop, S),
     {stop, stream_limit_reached};
 start_completed(_Stream, #{status := Other } = Prop, S) ->
-    ?LOG(error, "QUIC_stream_start_failed", Prop, S),
+    ?LOG(error, "quic_stream_start_failed", Prop, S),
     %% or we could retry?
     {stop, {start_fail, Other}, S}.
 
@@ -113,7 +113,7 @@ start_completed(_Stream, #{status := Other } = Prop, S) ->
 handle_stream_data(Stream, Bin, _Flags, #{ is_local := true
                                          , control_stream_sock := {quic, Conn, _ControlStream}
                                          , stream_parse_state := PSS} = S) ->
-    ?LOG(debug, "RECV_Data", #{data => Bin}, S),
+    ?LOG(debug, "recv_data", #{data => Bin}, S),
     Via = {quic, Conn, Stream},
     case maps:get(Via, PSS, undefined) of
         undefined ->

--- a/src/emqtt_ws.erl
+++ b/src/emqtt_ws.erl
@@ -47,9 +47,12 @@ connect(Host0, Port, Opts, Timeout) ->
     ConnOpts = maps:merge(Opts1, DefaultOpts),
     case gun:open(Host1, Port, ConnOpts) of
         {ok, ConnPid} ->
-            {ok, _} = gun:await_up(ConnPid, Timeout),
-            case upgrade(ConnPid, Opts, Timeout) of
-                {ok, _Headers} -> {ok, ConnPid};
+            case gun:await_up(ConnPid, Timeout) of
+                {ok, _} ->
+                    case upgrade(ConnPid, Opts, Timeout) of
+                        {ok, _Headers} -> {ok, ConnPid};
+                        Error -> Error
+                    end;
                 Error -> Error
             end;
         Error -> Error

--- a/test/emqtt_SUITE.erl
+++ b/test/emqtt_SUITE.erl
@@ -513,15 +513,9 @@ t_reconnect_reach_max_attempts(Config) ->
     ok = emqtt_test_lib:stop_emqx(),
 
     receive
-        {'DOWN', MRef, process, C, _Info} ->
-            receive
-                {'EXIT', C, {reconnect_error, _}} ->
-                    ok
-            after 100 ->
-                    ct:fail(no_exit)
-            end
+        {'DOWN', MRef, process, C, {shutdown, fake_conn_error}} -> ok
     after 5000 ->
-            ct:fail(conn_still_alive)
+        ct:fail(conn_still_alive)
     end,
     meck:unload(emqtt_sock),
     unmock_quic().


### PR DESCRIPTION
- avoid OTP crash report by wrapping exit reason in `{shutdown,Reason}`
- reformat some code for readability