### PR TITLE
fix: eval `disconnected` callback when reconnecting

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 - Support QoE tcp latency tracking in SSL case.
 - Fix: `disconnected` callback handler was not being called when `reconnect` is set.
 - Fix: reply `{error, tcp_closed}` to `emqtt:connect` caller if the socket was closed while waiting for `CONNACK`.
+- Introduce new `reconnect` event (and corresponding message handler) that is triggered whenever the client process starts a reconnect attempt.
 
 # 1.13.5
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 - Fix a typo in MQTT v3 reason code.
 - Support QoE tcp latency tracking in SSL case.
 - Fix: `disconnected` callback handler was not being called when `reconnect` is set.
+- Fix: reply `{error, tcp_closed}` to `emqtt:connect` caller if the socket was closed while waiting for `CONNACK`.
 
 # 1.13.5
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,8 @@
 # 1.13.6
 
 - Fix a typo in MQTT v3 reason code.
-- Support QoE tcp latency tracking in SSL case. 
+- Support QoE tcp latency tracking in SSL case.
+- Fix: `disconnected` callback handler was not being called when `reconnect` is set.
 
 # 1.13.5
 

--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -2076,6 +2076,7 @@ apply_callback_function({M, F, A}, Result)
     erlang:apply(M, F, A ++ [Result]).
 
 maybe_reconnect(Reason, #state{reconnect = Re} = State) when ?NEED_RECONNECT(Re) ->
+    eval_msg_handler(State, disconnected, Reason),
     enter_reconnect(Reason, State);
 maybe_reconnect(Reason, State) ->
     shutdown(Reason, State).


### PR DESCRIPTION
Otherwise, callers cannot keep track of disconnection reasons when using `reconnect`.