### PR TITLE
fix(quic): correct handle peer recv abort

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -47,7 +47,7 @@ jobs:
               cd _packages
               for var in $(ls); do echo $(sha256sum $var | awk "{print $1}") > $var.sha256; done
             '
-        - uses: actions/upload-artifact@v3
+        - uses: actions/upload-artifact@v4
           if: ${{ github.event_name == 'release' }}
           with:
             name: packages
@@ -80,7 +80,7 @@ jobs:
             .github/workflows/script/build.sh
             pkg=emqtt-macos-$(git describe --tags --always).zip
             openssl dgst -sha256 _packages/$pkg | awk '{print $2}' > _packages/$pkg.sha256
-        - uses: actions/upload-artifact@v3
+        - uses: actions/upload-artifact@v4
           if: ${{ github.event_name == 'release' }}
           with:
             name: packages-mac

--- a/.github/workflows/run_test_case.yaml
+++ b/.github/workflows/run_test_case.yaml
@@ -43,12 +43,12 @@ jobs:
             # copy the build dir to host working dir for following build steps
             docker cp testcontainer:/_w/_build .
             docker rm -f testcontainer
-        - uses: actions/upload-artifact@v3
+        - uses: actions/upload-artifact@v4
           if: always()
           with:
             name: logs
             path: _build/test/logs
-        - uses: actions/upload-artifact@v3
+        - uses: actions/upload-artifact@v4
           with:
             name: cover
             path: _build/test/cover

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -43,7 +43,7 @@ NewProfiles = lists:foldl(fun(Key, Acc) ->
 
 NewConfig = lists:keystore(profiles, 1, CONFIG, {profiles, NewProfiles}),
 
-Quicer = {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.1.8"}}},
+Quicer = {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.2.4"}}},
 KillQuicer = fun(C) ->
                 {deps, Deps0} = lists:keyfind(deps, 1, C),
                 {erl_opts, ErlOpts0} = lists:keyfind(erl_opts, 1, C),

--- a/src/emqtt_quic_stream.erl
+++ b/src/emqtt_quic_stream.erl
@@ -62,10 +62,10 @@ peer_accepted(_Stream, undefined, _S) ->
 -spec peer_receive_aborted(stream_handle(), non_neg_integer(), cb_data()) -> cb_ret().
 peer_receive_aborted(Stream, ErrorCode, #{is_unidir := false} = _S) ->
     %% we abort send with same reason
-    _ = quicer:async_shutdown_stream(Stream, ?QUIC_STREAM_SHUTDOWN_FLAG_ABORT, ErrorCode),
+    _ = quicer:async_shutdown_stream(Stream, ?QUIC_STREAM_SHUTDOWN_FLAG_ABORT_SEND, ErrorCode),
     keep_state_and_data;
 peer_receive_aborted(Stream, ErrorCode, #{is_unidir := true, is_local := true} = _S) ->
-    _ = quicer:async_shutdown_stream(Stream, ?QUIC_STREAM_SHUTDOWN_FLAG_ABORT, ErrorCode),
+    _ = quicer:async_shutdown_stream(Stream, ?QUIC_STREAM_SHUTDOWN_FLAG_ABORT_SEND, ErrorCode),
     keep_state_and_data.
 
 -spec peer_send_aborted(stream_handle(), non_neg_integer(), cb_data()) -> cb_ret().


### PR DESCRIPTION

After peer abort recv, emqtt should abort send direction,
instead of aborting both dir.

also bump 0.2.4 which is unrelated to this fix.