### PR TITLE
fix(ws): correctly adopt Gun 2.x interfaces

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,10 @@
+# 1.14.2
+
+- WebSocket: Correctly adopt Gun 2.x interfaces and semantics.
+
 # 1.14.1
 
-- QUIC: Correctly handle peer stream recv abort. 
+- QUIC: Correctly handle peer stream recv abort.
 - TLS1.3: Fix crash after recv session ticket
 
 # 1.14.0

--- a/src/emqtt_ws.erl
+++ b/src/emqtt_ws.erl
@@ -25,9 +25,10 @@
         , getstat/2
         ]).
 
--type(option() :: {ws_path, string()}).
+-type option() :: {ws_path, string()}.
+-type connection() :: {_Conn :: pid(), gun:stream_ref()}.
 
--export_type([option/0]).
+-export_type([option/0, connection/0]).
 
 -define(WS_OPTS, #{compress => false,
                    protocols => [{<<"mqtt">>, gun_ws_h}]

--- a/src/emqtt_ws.erl
+++ b/src/emqtt_ws.erl
@@ -42,8 +42,7 @@ connect(Host0, Port, Opts, Timeout) ->
     %% 1. open connection
     TransportOptions = proplists:get_value(ws_transport_options, Opts, []),
     ConnOpts = opts(TransportOptions, #{connect_timeout => Timeout,
-                                             retry => 3,
-                                             retry_timeout => 30000}),
+                                        retry => 0}),
     case gun:open(Host1, Port, ConnOpts) of
         {ok, ConnPid} ->
             case gun:await_up(ConnPid, Timeout) of


### PR DESCRIPTION
Accidentally overlooked in https://github.com/emqx/emqtt/pull/271.

See individual commits for details.