### PR TITLE
Please update README with latest version for rebar3 config

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ Add to `rebar.config`
 
 ```erlang
 ...
-{deps, [{emqtt, {git, "https://github.com/emqx/emqtt", {tag, "v1.2.0"}}}]}.
+{deps, [{emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.14.4"}}}]}.
 ...
 ```
 


### PR DESCRIPTION
v.1.2.0 seems to be out of date, it didn't compile with my setup and then I noticed that v1.2.0 was four years old!

Only once I switched to 1.14.4 did everything work. 

