### PR TITLE
fix: hanging process when TLS alert happens during mqtt_connect (`tls_alert`)

### DIFF
--- a/.github/workflows/run_test_case.yaml
+++ b/.github/workflows/run_test_case.yaml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 docker_image:
-                  - "ghcr.io/emqx/emqx-builder/5.3-13:1.15.7-26.2.5.2-1-ubuntu22.04"
+                  - "ghcr.io/emqx/emqx-builder/5.5-2:1.18.3-27.2-3-ubuntu24.04"
 
         steps:
         - name: Checkout

--- a/rebar.config
+++ b/rebar.config
@@ -25,7 +25,6 @@
             [ {meck, "1.0.0"}
             , {emqx, {git_subdir, "https://github.com/emqx/emqx", {branch, "master"}, "apps/emqx"}}
             , {emqx_utils, {git_subdir, "https://github.com/emqx/emqx", {branch, "master"}, "apps/emqx_utils"}}
-            , {emqx_limiter, {git_subdir, "https://github.com/emqx/emqx", {branch, "master"}, "apps/emqx/src/emqx_limiter"}}
             , {emqx_durable_storage, {git_subdir, "https://github.com/emqx/emqx", {branch, "master"}, "apps/emqx_durable_storage"}}
             , {emqx_ds_backends, {git_subdir, "https://github.com/emqx/emqx", {branch, "master"}, "apps/emqx_ds_backends"}}
             , {emqx_ds_builtin_local, {git_subdir, "https://github.com/emqx/emqx", {branch, "master"}, "apps/emqx_ds_builtin_local"}}

--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -1040,6 +1040,11 @@ do_connect(ConnMod, #state{pending_calls = Pendings,
                     %% connect on a TLS socket, for example, if the client's TLS
                     %% certificate is revoked and the server closes the connection.
                     {error, closed};
+                {error, {tls_alert, _} = Reason} ->
+                    %% If we receive a TLS alert here such as `Certificate Revoked`, there
+                    %% is no other socket event to be received, and thus we must terminate
+                    %% now to avoid hanging and then getting a `{error, connack_timeout}`.
+                    {error, Reason};
                 {error, Reason} ->
                     ?LOG(info, "failed_to_send_connect_packet", #{reason => Reason}, State),
                     %% Failed to send CONNECT packet.

--- a/test/emqtt_test_lib.erl
+++ b/test/emqtt_test_lib.erl
@@ -139,7 +139,7 @@ listener_conf(ws) ->
         mqtt_piggyback => multiple,
         proxy_address_header => "x-forwarded-for",
         proxy_port_header => "x-forwarded-port",
-        supported_subprotocols => ["mqtt","mqtt-v3","mqtt-v3.1.1","mqtt-v5"],
+        supported_subprotocols => [<<"mqtt">>,<<"mqtt-v3">>,<<"mqtt-v3.1.1">>,<<"mqtt-v5">>],
         validate_utf8 => true}
      };
 listener_conf(_) -> #{}.

--- a/test/emqtt_test_lib.erl
+++ b/test/emqtt_test_lib.erl
@@ -46,7 +46,6 @@ all(Suite) ->
 -spec start_emqx() -> ok.
 start_emqx() ->
     ensure_test_module(emqx_common_test_helpers),
-    ensure_test_module(emqx_ratelimiter_SUITE),
     emqx_common_test_helpers:start_apps([]),
     ok = ensure_quic_listener(mqtt, 14567),
     ok.


### PR DESCRIPTION
Similar to https://github.com/emqx/emqtt/pull/279

This time, the error is a bit different, but the effect is the same:

```
18:17:09.437 [info] [reason: {:tls_alert, {:certificate_revoked, ~c"TLS client: In state connection received SERVER ALERT: Fatal - Certificate Revoked\n"}}, msg: ~c"failed_to_send_connect_packet", clientid: "emqtt-erlang-9e2056f5415da439bfce"]
```

```
Testing apps.emqx.emqx_crl_cache_SUITE: *** FAILED test case 1 ***
%%% emqx_crl_cache_SUITE ==> t_revoked: FAILED
%%% emqx_crl_cache_SUITE ==> {{case_clause,{error,connack_timeout}},
 [{emqx_crl_cache_SUITE,t_revoked,1,
                        [{file,"test/emqx_crl_cache_SUITE.erl"},{line,969}]},
  {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1794}]},
  {test_server,run_test_case_eval1,6,[{file,"test_server.erl"},{line,1303}]},
  {test_server,run_test_case_eval,9,[{file,"test_server.erl"},{line,1235}]}]}
```

Simple to reproduce with a small sleep before `mqtt_connect`:

```diff
modified   src/emqtt.erl
@@ -1032,6 +1032,7 @@ do_connect(ConnMod, #state{pending_calls = Pendings,
                                            socket = NewSock,
                                            pending_calls = NewPendings
                                           }),
+            timer:sleep(50),
             case mqtt_connect(State3) of
                 {ok, State4} ->
                     {ok, State4};
```