### PR TITLE
feat: respect pingresp timeout

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,12 +23,12 @@
     [{test,
         [{deps,
             [ {meck, "1.0.0"}
-            , {emqx, {git_subdir, "https://github.com/emqx/emqx", {branch, "master"}, "apps/emqx"}}
-            , {emqx_utils, {git_subdir, "https://github.com/emqx/emqx", {branch, "master"}, "apps/emqx_utils"}}
-            , {emqx_durable_storage, {git_subdir, "https://github.com/emqx/emqx", {branch, "master"}, "apps/emqx_durable_storage"}}
-            , {emqx_ds_backends, {git_subdir, "https://github.com/emqx/emqx", {branch, "master"}, "apps/emqx_ds_backends"}}
-            , {emqx_ds_builtin_local, {git_subdir, "https://github.com/emqx/emqx", {branch, "master"}, "apps/emqx_ds_builtin_local"}}
-            , {emqx_ds_builtin_raft, {git_subdir, "https://github.com/emqx/emqx", {branch, "master"}, "apps/emqx_ds_builtin_raft"}}
+            , {emqx, {git_subdir, "https://github.com/emqx/emqx", {tag, "e5.10.0"}, "apps/emqx"}}
+            , {emqx_utils, {git_subdir, "https://github.com/emqx/emqx", {tag, "e5.10.0"}, "apps/emqx_utils"}}
+            , {emqx_durable_storage, {git_subdir, "https://github.com/emqx/emqx", {tag, "e5.10.0"}, "apps/emqx_durable_storage"}}
+            , {emqx_ds_backends, {git_subdir, "https://github.com/emqx/emqx", {tag, "e5.10.0"}, "apps/emqx_ds_backends"}}
+            , {emqx_ds_builtin_local, {git_subdir, "https://github.com/emqx/emqx", {tag, "e5.10.0"}, "apps/emqx_ds_builtin_local"}}
+            , {emqx_ds_builtin_raft, {git_subdir, "https://github.com/emqx/emqx", {tag, "e5.10.0"}, "apps/emqx_ds_builtin_raft"}}
             , {proper, "1.4.0"}
             , {esasl, {git, "https://github.com/emqx/esasl", {tag, "0.2.1"}}}
             , {sasl_auth, {git, "https://github.com/kafka4beam/sasl_auth.git", {tag, "v2.2.0"}}}


### PR DESCRIPTION
Fixes [EMQX-14540](https://emqx.atlassian.net/browse/EMQX-14540)

Seems that `emqtt` treats keepalive as means to report its own liveness to the broker, but not to check the broker presence.
When `emqtt` sends `PINGREQ` on keepalive timer, it doesn't check that a `PINGRESP` comes. 

So if a TCP connection gets stalled (no packets find their routes), `emqtt` does not react to this.

However MQTT spec advises to close connection if `PINGRESP` is absent (3.1.2.10 Keep Alive):

> If a Client does not receive a PINGRESP packet within a reasonable amount of time after it has sent a PINGREQ, it SHOULD close the Network Connection to the Server.

So we introduce a timer to detect `PINGRESP` absence and close the connection. We do not schedule this timer on manual `ping` call assuming that the caller will take the decisions themself. 

