### PR TITLE
fix: emqtt should respect the sockopt active_n

### DIFF
--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -357,6 +357,8 @@
 
 -define(NEED_RECONNECT(Re), (Re == infinity orelse (is_integer(Re) andalso Re > 0))).
 
+-define(DEFAULT_SOCK_ACTIVE, once).
+
 -define(SOCK_ERROR(E), (E =:= tcp_error orelse
                         E =:= ssl_error orelse
                         E =:= quic_error orelse
@@ -1038,10 +1040,12 @@ do_connect(ConnMod, #state{pending_calls = Pendings,
             State1 = maybe_update_ctrl_sock(ConnMod, State0, NewSock),
             State2 = qoe_inject(handshaked, maybe_qoe_tcp(State1)),
             NewPendings = refresh_calls(Pendings, NewSock),
-            State3 = run_sock(State2#state{conn_mod = ConnMod,
-                                           socket = NewSock,
-                                           pending_calls = NewPendings
-                                          }),
+            %% Apply the sock opt 'active', as the sock was started in 'passive' mode.
+            State3 = State2#state{conn_mod = ConnMod,
+                                  socket = NewSock,
+                                  pending_calls = NewPendings
+                                 },
+            _ = run_sock(State3),
             case mqtt_connect(State3) of
                 {ok, State4} ->
                     {ok, State4};
@@ -1531,6 +1535,12 @@ handle_event({call, From}, stop, _StateName, _State) ->
 
 handle_event({call, From}, status, StateName, _State) ->
     {keep_state_and_data, {reply, From, StateName}};
+
+handle_event(info, {Passive, Sock}, _StateName, #state{socket = Sock} = State) 
+  when Passive =:= tcp_passive orelse Passive =:= ssl_passive ->
+    %% Auto reactivate the sock
+    _ = activate_sock(State),
+    keep_state_and_data;
 
 handle_event(info, {gun_ws, ConnPid, StreamRef, {binary, Data}},
              _StateName, State = #state{socket = {ConnPid, StreamRef}}) ->
@@ -2246,12 +2256,29 @@ send(Sock, Packet, State = #state{conn_mod = ConnMod, proto_ver = Ver})
 
 run_sock(State = #state{conn_mod = emqtt_quic}) ->
     State;
-run_sock(State = #state{conn_mod = ConnMod, socket = Sock}) ->
-    %% error is discarded, if socket is already closed,
-    %% so the next 'send' call will return {error, closed} or {error, einval}
-    %% then it should decide if it should shutdown or retry
-    _ = ConnMod:setopts(Sock, [{active, once}]),
+run_sock(State = #state{conn_mod = ConnMod, socket = Sock, sock_opts = Opts}) ->
+    case proplists:get_value(active, Opts, ?DEFAULT_SOCK_ACTIVE) of
+        once ->
+            %% error is discarded, if socket is already closed,
+            %% so the next 'send' call will return {error, closed} or {error, einval}
+            %% then it should decide if it should shutdown or retry 
+            set_active(ConnMod, Sock, once);
+        _ -> 
+            %% No need to set for the other values 
+            ok
+    end,
     State.
+
+-spec activate_sock(state()) -> ok.
+activate_sock(#state{conn_mod = ConnMod, socket = Sock, sock_opts = Opts}) ->
+    V = proplists:get_value(active, Opts, ?DEFAULT_SOCK_ACTIVE),
+    set_active(ConnMod, Sock, V).
+
+set_active(emqtt_quic, _Sock, _V) ->
+    ok;
+set_active(ConnMod, Sock, V) ->
+    _ = ConnMod:setopts(Sock, [{active, V}]),
+    ok.
 
 %%--------------------------------------------------------------------
 %% Process incomming

--- a/test/emqtt_SUITE.erl
+++ b/test/emqtt_SUITE.erl
@@ -101,7 +101,10 @@ groups() ->
        t_connected,
        t_qos2_flow_autoack_never,
        t_ssl_error_client_reject_server,
-       t_ssl_error_server_reject_client]},
+       t_ssl_error_server_reject_client,
+       t_active_default_recv,
+       t_active_n_rearm]},
+
     {mqttv3,[],
       [basic_test_v3]},
     {mqttv4, [],
@@ -1649,6 +1652,64 @@ retain_as_publish_test(Config) ->
 
     ok = emqtt:disconnect(Pub),
     clean_retained(Topic).
+
+t_active_default_recv(Config) ->
+    ConnFun = ?config(conn_fun, Config),
+    Port = ?config(port, Config),
+    Topic = atom_to_binary(?FUNCTION_NAME),
+    {ok, Sub} = emqtt:start_link([{clean_start, true}, {port, Port}]),
+    {ok, _} = emqtt:ConnFun(Sub),
+    SockOpts = proplists:get_value(sock_opts, emqtt:info(Sub)),
+    ?assertEqual(once, proplists:get_value(active, SockOpts, once)),
+    {ok, _, _} = emqtt:subscribe(Sub, Topic, ?QOS_0),
+    {ok, Pub} = emqtt:start_link([{clean_start, true}, {port, Port}]),
+    {ok, _} = emqtt:ConnFun(Pub),
+    N = 5,
+    lists:foreach(
+        fun(I) ->
+            ok = emqtt:publish(Pub, Topic, integer_to_binary(I), ?QOS_0)
+        end,
+        lists:seq(1, N)
+    ),
+    ?assertEqual(N, length(receive_messages(N))),
+    ok = emqtt:disconnect(Sub),
+    ok = emqtt:disconnect(Pub).
+
+t_active_n_rearm(Config) ->
+    ConnFun = ?config(conn_fun, Config),
+    case ConnFun of
+        quic_connect ->
+            ct:pal("skipped: active_n tcp test is not applicable for QUIC", []),
+            ok;
+        _ ->
+            Port = ?config(port, Config),
+            Topic = atom_to_binary(?FUNCTION_NAME),
+            ActiveN = 3,
+            {ok, Sub} = emqtt:start_link([{clean_start, true}, {port, Port},
+                                           {tcp_opts, [{active, ActiveN}]}]),
+            {ok, _} = emqtt:connect(Sub),
+            SockOpts = proplists:get_value(sock_opts, emqtt:info(Sub)),
+            ?assertEqual(ActiveN, proplists:get_value(active, SockOpts)),
+            {ok, _, _} = emqtt:subscribe(Sub, Topic, ?QOS_1),
+            NumMsgs = ActiveN * 2 + 1,
+            {ok, Pub} = emqtt:start_link([{clean_start, true}, {port, Port}]),
+            {ok, _} = emqtt:connect(Pub),
+            lists:foreach(
+                fun(I) ->
+                    {ok, _} = emqtt:publish(Pub, Topic, integer_to_binary(I), [{qos, 1}])
+                end,
+                lists:seq(1, NumMsgs)
+            ),
+            %% Receiving all messages proves activate_sock re-armed the socket
+            %% with ActiveN after each tcp_passive event
+            ?assertEqual(NumMsgs, length(receive_messages(NumMsgs))),
+            %% Socket must be set to {active, ActiveN}, not {active, once}
+            Sock = proplists:get_value(socket, emqtt:info(Sub)),
+            {ok, [{active, ActiveNow}]} = inet:getopts(Sock, [active]),
+            ?assert((ActiveNow > 0 andalso ActiveNow =< ActiveN) orelse ActiveNow =:= false),
+            ok = emqtt:disconnect(Sub),
+            ok = emqtt:disconnect(Pub)
+    end.
 
 merge_config(Config1, Config2) ->
     lists:foldl(

--- a/test/emqtt_sock_SUITE.erl
+++ b/test/emqtt_sock_SUITE.erl
@@ -223,7 +223,7 @@ send_and_recv_with(Sock) ->
 tlsv13_connect_test(Config) ->
     ServerSslOpts = ?config(server_ssl_opts, Config),
     ClientSslOpts = ?config(client_ssl_opts, Config),
-    Port = 1024 + random:uniform(erlang:system_info(port_limit) - 1024),
+    Port = 1024 + rand:uniform(erlang:system_info(port_limit) - 1024),
     {Server, _} = ssl_server:start_link(Port, ServerSslOpts),
     {ok, Sock} = emqtt_sock:connect(?config(target_host, Config), Port, [{ssl_opts, ClientSslOpts}], 3000),
     send_and_recv_with(Sock),


### PR DESCRIPTION
Without this change, the erlang TCP port of emqtt client is hardcoded to be '{active, once}' no matter what tcp option active get passed. This PR makes emqtt respect the socket opt `active` in the arg of `start_link`

by making the active_n configurable, we could utilize the `Scheduler pollset`
in https://www.erlang.org/doc/apps/erts/checkio.html.

keep the default as `{active, once}`


from test result: 
active = 100, scheduler epoll will be used, lower latency for high frequency messagings. 
active = 10, scheduler epoll will NOT be used, use MORE sys CPU (due to epoll oneshoot) under high frequency messagings (QoS 1) but it could handle more concurrent connections if connections are having low frequency messagings.


NOTE: TLS doesn't work yet due to : https://github.com/erlang/otp/issues/11108
