### PR TITLE
fix: do not merge MQTT v5 directional props from CONNACK

### DIFF
--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -107,6 +107,11 @@
 %% export for internal calls
 -export([sync_publish_result/3]).
 
+-ifdef(TEST).
+%% Exported only for eunit (see test/emqtt_tests.erl).
+-export([connack_properties_to_merge/1]).
+-endif.
+
 -ifdef(UPGRADE_TEST_CHEAT).
 -export([format_status/2]).
 -endif.
@@ -1152,9 +1157,19 @@ waiting_for_connack(cast, {?CONNACK_PACKET(?RC_SUCCESS,
                                    socket = Via,
                                    proto_ver = Ver
                                   }) ->
+    %% MQTT v5: a few property identifiers are valid in both CONNECT and
+    %% CONNACK but describe the OPPOSITE direction of the connection. The
+    %% client-supplied value (CONNECT) is the limit that applies to traffic
+    %% from broker -> client; the broker-supplied value (CONNACK) is the
+    %% limit that applies to traffic from client -> broker. Blindly
+    %% merging the CONNACK map over the State's CONNECT map would clobber
+    %% the client-side limit. See MQTT v5 spec sections 3.2.2.3.3
+    %% (Receive Maximum), 3.2.2.3.6 (Maximum Packet Size) and 3.2.2.3.8
+    %% (Topic Alias Maximum). `connack_properties_to_merge/1' drops those
+    %% directional keys before merging.
     AllProps1 = case Properties of
                     undefined -> AllProps;
-                    _ -> maps:merge(AllProps, Properties)
+                    _ -> maps:merge(AllProps, connack_properties_to_merge(Properties))
                 end,
     Reply = {ok, Properties},
     State1 = State#state{clientid = assign_id(ClientId, Ver, AllProps1),
@@ -1167,7 +1182,18 @@ waiting_for_connack(cast, {?CONNACK_PACKET(?RC_SUCCESS,
     %% This is fine for the initial connection, but for reconnections, it's not clear what
     %% to do if the `Receive-Maximum` is reduced and is now less than the inflight size
     %% (see `connected(info, immediate_retry, ...)` below).
-    ReceiveMaximum = maps:get('Receive-Maximum', AllProps1, infinity),
+    %%
+    %% NOTE: read `Receive-Maximum' from the raw CONNACK properties rather
+    %% than `AllProps1', because the merge above intentionally drops the
+    %% broker's `Receive-Maximum' (it is the client->broker limit, not the
+    %% client's own broker->client limit declared in CONNECT). The inflight
+    %% window we cap here is precisely how many unacked PUBLISHes we may
+    %% have in flight TO the broker, so the broker's CONNACK value is the
+    %% authoritative one to use.
+    ReceiveMaximum = case Properties of
+                         undefined -> infinity;
+                         _ -> maps:get('Receive-Maximum', Properties, infinity)
+                     end,
     Inflight1 = emqtt_inflight:limit(ReceiveMaximum, Inflight),
     State4 = State3#state{inflight = Inflight1},
     Retry = [{next_event, info, immediate_retry} || not emqtt_inflight:is_empty(Inflight1)],
@@ -1899,6 +1925,34 @@ assign_id(Id, Ver, Props) when Id =:= ?NO_CLIENT_ID orelse Id =:= undefined ->
     end;
 assign_id(Id, _Ver, _Props) ->
     Id.
+
+%% @doc Filter broker-sent CONNACK properties to those whose value should
+%% replace the client-side value in `State#state.properties'.
+%%
+%% MQTT v5 property identifiers 0x21 (`Receive-Maximum'), 0x22
+%% (`Topic-Alias-Maximum') and 0x27 (`Maximum-Packet-Size') are valid in
+%% both CONNECT and CONNACK, but the two occurrences describe opposite
+%% directions of the connection:
+%%
+%%   - In CONNECT, the property is the LIMIT THE CLIENT IMPOSES on the
+%%     traffic it will accept FROM the broker (broker -> client).
+%%   - In CONNACK, the property is the LIMIT THE BROKER IMPOSES on the
+%%     traffic it will accept FROM the client (client -> broker).
+%%
+%% See MQTT v5 spec sections 3.1.2.11.3 / 3.2.2.3.3 (Receive Maximum),
+%% 3.1.2.11.4 / 3.2.2.3.6 (Maximum Packet Size) and 3.1.2.11.5 /
+%% 3.2.2.3.8 (Topic Alias Maximum).
+%%
+%% These three properties must therefore NOT be merged from the CONNACK
+%% map into the client-side state, otherwise we would silently overwrite
+%% the client-declared limit. Code that actually needs the broker-side
+%% value (e.g. inflight window sizing for client -> broker traffic) must
+%% read it from the raw CONNACK properties.
+-spec connack_properties_to_merge(properties()) -> properties().
+connack_properties_to_merge(Properties) when is_map(Properties) ->
+    maps:without(['Receive-Maximum',
+                  'Topic-Alias-Maximum',
+                  'Maximum-Packet-Size'], Properties).
 
 publish_qos1(Via, Packet = ?PUBLISH_PACKET(?QOS_1, PacketId),
              State0 = #state{auto_ack = AutoAck}) ->

--- a/test/emqtt_SUITE.erl
+++ b/test/emqtt_SUITE.erl
@@ -936,9 +936,9 @@ t_drop_calls_on_reconnect(Config) ->
     meck:new(emqx_access_control, [passthrough, no_history]),
     meck:expect(emqx_access_control,
                 authorize,
-                fun(ClientInfo, PubSub, Topic) ->
+                fun(ClientInfo, PubSub, Topic1) ->
                         timer:sleep(2000),
-                        meck:passthrough([ClientInfo, PubSub, Topic])
+                        meck:passthrough([ClientInfo, PubSub, Topic1])
                 end),
 
     %% Subscribe

--- a/test/emqtt_tests.erl
+++ b/test/emqtt_tests.erl
@@ -1,0 +1,97 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+%% eunit tests for `emqtt'. Named `emqtt_tests' so it is auto-discovered
+%% when running eunit against the `emqtt' module.
+-module(emqtt_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%--------------------------------------------------------------------
+%% connack_properties_to_merge/1
+%%
+%% Regression coverage: MQTT v5 property identifiers 0x21 (Receive
+%% Maximum), 0x22 (Topic Alias Maximum) and 0x27 (Maximum Packet Size)
+%% appear in both CONNECT and CONNACK with OPPOSITE directional meaning.
+%% The broker's CONNACK value must NOT overwrite the client's CONNECT
+%% value in `State#state.properties'.
+%%--------------------------------------------------------------------
+
+%% Directional properties (broker's CONNACK value applies to
+%% client -> broker direction, NOT a replacement for the client's CONNECT
+%% value) MUST be dropped before merging into the client-side property
+%% map.
+connack_properties_to_merge_drops_directional_props_test() ->
+    BrokerProps = #{'Receive-Maximum'     => 10,
+                    'Topic-Alias-Maximum' => 5,
+                    'Maximum-Packet-Size' => 1024,
+                    'Server-Keep-Alive'   => 30},
+    Merged = emqtt:connack_properties_to_merge(BrokerProps),
+    ?assertNot(maps:is_key('Receive-Maximum', Merged)),
+    ?assertNot(maps:is_key('Topic-Alias-Maximum', Merged)),
+    ?assertNot(maps:is_key('Maximum-Packet-Size', Merged)),
+    ?assertEqual(#{'Server-Keep-Alive' => 30}, Merged).
+
+%% Broker-authoritative / CONNACK-only properties MUST be kept so they
+%% can override or augment the client-side property map.
+connack_properties_to_merge_keeps_broker_authoritative_props_test() ->
+    BrokerProps = #{'Assigned-Client-Identifier'        => <<"c1">>,
+                    'Server-Keep-Alive'                 => 30,
+                    'Session-Expiry-Interval'           => 60,
+                    'Maximum-QoS'                       => 1,
+                    'Retain-Available'                  => 0,
+                    'Wildcard-Subscription-Available'   => 1,
+                    'Subscription-Identifier-Available' => 1,
+                    'Shared-Subscription-Available'     => 1,
+                    'Reason-String'                     => <<"ok">>,
+                    'Response-Information'              => <<"resp/">>,
+                    'Server-Reference'                  => <<"other:1883">>,
+                    'Authentication-Method'             => <<"SCRAM-SHA-1">>,
+                    'Authentication-Data'               => <<"data">>,
+                    'User-Property'                     => [{<<"k">>, <<"v">>}]},
+    ?assertEqual(BrokerProps, emqtt:connack_properties_to_merge(BrokerProps)).
+
+%% Simulate the actual merge in `waiting_for_connack': the client's
+%% CONNECT-side directional properties must survive the merge with the
+%% broker's CONNACK properties.
+connack_merge_preserves_client_directional_props_test() ->
+    %% Client declared these limits in CONNECT (they govern
+    %% broker -> client traffic, e.g. how big a packet the client can
+    %% parse, what topic aliases the broker may use when publishing to
+    %% the client, how many concurrent unacked QoS>0 PUBLISHes the broker
+    %% may push to us).
+    ClientProps = #{'Receive-Maximum'     => 32,
+                    'Topic-Alias-Maximum' => 16,
+                    'Maximum-Packet-Size' => 65536},
+    %% Broker returned these limits in CONNACK (they govern
+    %% client -> broker traffic). They share property identifiers with
+    %% the CONNECT ones but mean something different and must not
+    %% overwrite the client's view.
+    BrokerProps = #{'Receive-Maximum'     => 4,
+                    'Topic-Alias-Maximum' => 2,
+                    'Maximum-Packet-Size' => 1024,
+                    'Server-Keep-Alive'   => 30},
+    Merged = maps:merge(ClientProps,
+                        emqtt:connack_properties_to_merge(BrokerProps)),
+    ?assertEqual(32,    maps:get('Receive-Maximum',     Merged)),
+    ?assertEqual(16,    maps:get('Topic-Alias-Maximum', Merged)),
+    ?assertEqual(65536, maps:get('Maximum-Packet-Size', Merged)),
+    %% Broker-only property still comes through.
+    ?assertEqual(30,    maps:get('Server-Keep-Alive',   Merged)).
+
+%% An empty broker properties map is a no-op.
+connack_properties_to_merge_empty_test() ->
+    ?assertEqual(#{}, emqtt:connack_properties_to_merge(#{})).


### PR DESCRIPTION
Receive-Maximum (0x21), Topic-Alias-Maximum (0x22) and Maximum-Packet-Size (0x27) are valid in both CONNECT and CONNACK but describe OPPOSITE directions of the connection:

  * CONNECT  -> client-imposed limit on broker -> client traffic
  * CONNACK  -> broker-imposed limit on client -> broker traffic

The previous `maps:merge(AllProps, Properties)` in `waiting_for_connack` silently overwrote the client's own (broker -> client) limits with the broker's (client -> broker) limits. Filter those three keys out via the new `connack_properties_to_merge/1` before merging into the State, and read the broker's `Receive-Maximum` for the inflight-window cap directly from the raw CONNACK properties (where the value is now the only place it lives).

See MQTT v5 spec sections 3.1.2.11.3 / 3.2.2.3.3 (Receive Maximum), 3.1.2.11.4 / 3.2.2.3.6 (Maximum Packet Size) and 3.1.2.11.5 / 3.2.2.3.8 (Topic Alias Maximum).

Adds eunit tests in test/emqtt_tests.erl covering the filter and the combined merge behavior.

Also: rename a shadowed `Topic` binding to `Topic1` in the meck callback of `t_drop_calls_on_reconnect`.