### PR TITLE
fix: peel #ssl_socket{} wrapper when matching ssl_passive event

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # 1.15.2
 
+- fix: re-arm the socket on `ssl_passive` events when `{active, N}` is configured.
+  The handler matched the event's sslsocket against the one stored in state,
+  which never matched because emqtt wraps the OTP `sslsocket` in its own
+  `#ssl_socket{tcp, ssl}` record. The handler now peels into the wrapper on the
+  SSL branch (#314).
+
+# 1.15.2
+
 - fix: do not merge MQTT v5 directional properties (`Receive-Maximum`,
   `Topic-Alias-Maximum`, `Maximum-Packet-Size`) from CONNACK into the
   client state. These properties describe opposite directions in

--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -1562,9 +1562,16 @@ handle_event({call, From}, stop, _StateName, _State) ->
 handle_event({call, From}, status, StateName, _State) ->
     {keep_state_and_data, {reply, From, StateName}};
 
-handle_event(info, {Passive, Sock}, _StateName, #state{socket = Sock} = State) 
-  when Passive =:= tcp_passive orelse Passive =:= ssl_passive ->
-    %% Auto reactivate the sock
+%% TLS: the OTP ssl driver delivers events with the bare sslsocket
+%% record; emqtt wraps it as #ssl_socket{tcp, ssl} in state. Peel
+%% into the wrapper to match.
+handle_event(info, {ssl_passive, SslSock}, _StateName,
+             #state{socket = #ssl_socket{ssl = SslSock}} = State) ->
+    _ = activate_sock(State),
+    keep_state_and_data;
+%% Plain TCP: state stores the raw inet socket, term-equality holds.
+handle_event(info, {tcp_passive, Sock}, _StateName,
+             #state{socket = Sock} = State) ->
     _ = activate_sock(State),
     keep_state_and_data;
 

--- a/test/emqtt_SUITE.erl
+++ b/test/emqtt_SUITE.erl
@@ -103,7 +103,8 @@ groups() ->
        t_ssl_error_client_reject_server,
        t_ssl_error_server_reject_client,
        t_active_default_recv,
-       t_active_n_rearm]},
+       t_active_n_rearm,
+       t_active_n_rearm_ssl]},
 
     {mqttv3,[],
       [basic_test_v3]},
@@ -1710,6 +1711,49 @@ t_active_n_rearm(Config) ->
             ok = emqtt:disconnect(Sub),
             ok = emqtt:disconnect(Pub)
     end.
+
+%% Verifies that {active, N} sockets re-arm correctly on TLS, so the
+%% subscriber keeps receiving past the first active-N window.
+t_active_n_rearm_ssl(Config) ->
+    %% Some test matrices ship an EMQX whose ssl:default listener requires
+    %% a client cert (mTLS). Force verify_none on just that field so the
+    %% test exercises the active-N rearm path and not cert-chain validation,
+    %% without clobbering the server's certfile/keyfile.
+    emqx_config:put_listener_conf(ssl, default, [ssl_options, verify], verify_none),
+    ok = emqx_listeners:restart_listener(<<"ssl:default">>),
+    Port = proplists:get_value(ssl_port, Config, 8883),
+    Topic = atom_to_binary(?FUNCTION_NAME),
+    ActiveN = 3,
+    SslOpts = [{verify, verify_none}],
+    {ok, Sub} = emqtt:start_link([{clean_start, true},
+                                  {port, Port},
+                                  {ssl, true},
+                                  {ssl_opts, SslOpts},
+                                  {tcp_opts, [{active, ActiveN}]}]),
+    {ok, _} = emqtt:connect(Sub),
+    SockOpts = proplists:get_value(sock_opts, emqtt:info(Sub)),
+    ?assertEqual(ActiveN, proplists:get_value(active, SockOpts)),
+    {ok, _, _} = emqtt:subscribe(Sub, Topic, ?QOS_1),
+
+    NumMsgs = ActiveN * 2 + 1,
+    {ok, Pub} = emqtt:start_link([{clean_start, true},
+                                  {port, Port},
+                                  {ssl, true},
+                                  {ssl_opts, SslOpts}]),
+    {ok, _} = emqtt:connect(Pub),
+    lists:foreach(
+      fun(I) ->
+              {ok, _} = emqtt:publish(Pub, Topic, integer_to_binary(I),
+                                      [{qos, 1}])
+      end,
+      lists:seq(1, NumMsgs)),
+
+    Received = receive_messages(NumMsgs),
+    ct:pal("received ~p of ~p expected messages", [length(Received), NumMsgs]),
+    ?assertEqual(NumMsgs, length(Received)),
+
+    ok = emqtt:disconnect(Sub),
+    ok = emqtt:disconnect(Pub).
 
 merge_config(Config1, Config2) ->
     lists:foldl(


### PR DESCRIPTION
## Summary

The handler that re-arms a `{active, N}` socket on a passive event used a single combined guard:

\`\`\`erlang
handle_event(info, {Passive, Sock}, _StateName, #state{socket = Sock} = State)
  when Passive =:= tcp_passive orelse Passive =:= ssl_passive ->
\`\`\`

For plain TCP this works — `State#state.socket` is the raw inet socket and matches the event's `Sock`. For TLS it silently fails: emqtt wraps the OTP `sslsocket` in its own `-record(ssl_socket, {tcp, ssl})` envelope (defined at `src/emqtt_internal.hrl:17`) and stores that wrapped form in state, while the OTP ssl driver delivers `{ssl_passive, SslSock}` with the bare `sslsocket` record. The guard equality fails, the event falls through to `handle_unknown_event/4` (`unexpected_event`), and the socket is never re-armed.

Diagnostic confirms (printed via a temporary instrumentation, then removed):

\`\`\`
stored: {ssl_socket, #Port<0.28>,
                     {sslsocket,{gen_tcp,#Port<0.28>,tls_connection,undefined},
                                [<0.2314.0>,<0.2313.0>]}}
event : {sslsocket,{gen_tcp,#Port<0.28>,tls_connection,undefined},
                   [<0.2314.0>,<0.2313.0>]}
equal?: false
\`\`\`

The inner `sslsocket` record is bit-identical on both sides — it's the outer `ssl_socket` wrapper that breaks the equality check.

## Fix

Split the clause in two and peel the wrapper on the SSL branch — same convention emqtt already uses for `ssl_error` and `ssl_closed` (`src/emqtt.erl:1586-1604`):

\`\`\`erlang
%% TLS
handle_event(info, {ssl_passive, SslSock}, _StateName,
             #state{socket = #ssl_socket{ssl = SslSock}} = State) ->
    _ = activate_sock(State),
    keep_state_and_data;
%% Plain TCP
handle_event(info, {tcp_passive, Sock}, _StateName,
             #state{socket = Sock} = State) ->
    _ = activate_sock(State),
    keep_state_and_data;
\`\`\`

This preserves socket-identity safety (stale events for replaced sockets are still filtered out) AND fixes TLS.

## Customer impact this closes

EMQX 6.1.2 and 6.2.1 ship emqtt 1.15.1 and set `tcp_opts.active_n = 10` as the default for MQTT bridges and Cluster Link. Every TLS bridge stalls after the first delivery. The customer-facing symptoms are `unexpected_event {ssl_passive, _}` in the broker log, followed by `async_reply_to_expired_request` and `buffer_worker_dropped_expired_messages`.

## Test

`t_active_n_rearm_ssl` mirrors the existing `t_active_n_rearm` but over TLS with `{active, 3}` and 7 publishes:

- Pre-fix: `expected: 7, value: 1` — subscriber receives only the very first delivery; CT log captures the `unexpected_event {ssl_passive, _}` warning.
- Post-fix: `received 7 of 7 expected messages` — 1 ok, 0 failed.