### PR TITLE
fix: clean, typed error reasons for failed connect attempts

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,17 @@
+# 1.15.4
+
+- fix: return clean, typed error reasons from failed connect attempts.
+  - Frame parse failures (e.g. receiving TLS handshake bytes after connecting
+    plain TCP to a TLS listener) now yield `{error, {frame_parse_error, Reason}}`
+    instead of `{error, {tcp, Port, Bytes}}` (the raw socket event) or a
+    `parse_packets_error` reason embedding a stacktrace. The parse failure
+    details (reason, stacktrace, offending bytes) are logged instead.
+  - Socket errors and closes while waiting for CONNACK reply the shutdown
+    reason itself rather than the raw socket event; e.g. a rejected TLS client
+    certificate now returns `{error, {tls_alert, {unknown_ca, _}}}` instead of
+    `{error, {ssl_error, Sock, {tls_alert, {unknown_ca, _}}}}`, and a closed
+    socket returns `{error, tcp_closed}` instead of `{error, {tcp_closed, Sock}}`.
+
 # 1.15.3
 
 - fix: re-arm the socket on `ssl_passive` events when `{active, N}` is configured.

--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -1261,10 +1261,12 @@ waiting_for_connack(EventType, EventContent, State) ->
             case take_call(call_id(connect, Via), NewState) of
                 {value, #call{from = From}, _State} ->
                     Reply = case Reason of
-                                {shutdown, _ShutdownReason} ->
-                                    %% All _ShutdownReason reasons returned from handle_event
-                                    %% are included in EventContext
-                                    {error, EventContent};
+                                {shutdown, ShutdownReason} ->
+                                    %% Reply with the shutdown reason, not the raw
+                                    %% event: the event may be a socket data message
+                                    %% like `{tcp, Port, Bytes}' which leaks the port
+                                    %% and payload to the caller as an error reason.
+                                    {error, ShutdownReason};
                                 _ ->
                                     {error, {Reason, EventContent}}
                             end,
@@ -2355,7 +2357,13 @@ process_incoming(Bytes, Packets, State = #state{parse_state = ParseState, socket
             {keep_state, State#state{parse_state = NParseState}, next_events(Via, Packets)}
     catch
         error:Reason:St ->
-            maybe_reconnect({parse_packets_error, Reason, St}, State)
+            %% Received bytes that do not parse as an MQTT frame, e.g. a TLS
+            %% handshake alert when connecting plain TCP to a TLS listener.
+            %% Log the details here; the process exit reason (and hence the
+            %% error callers see) carries only a compact, typed term.
+            ?LOG(error, "frame_parse_error",
+                 #{reason => Reason, stacktrace => St, data => Bytes}, State),
+            maybe_reconnect({frame_parse_error, Reason}, State)
     end.
 
 -compile({inline, [next_events/2]}).

--- a/test/emqtt_SUITE.erl
+++ b/test/emqtt_SUITE.erl
@@ -102,6 +102,7 @@ groups() ->
        t_qos2_flow_autoack_never,
        t_ssl_error_client_reject_server,
        t_ssl_error_server_reject_client,
+       t_frame_parse_error,
        t_active_default_recv,
        t_active_n_rearm,
        t_active_n_rearm_ssl]},
@@ -311,7 +312,43 @@ t_ssl_error_server_reject_client(Config) ->
                                            ]}
                                ]),
     {error, Reason} = emqtt:connect(C),
-    ?assertMatch({ssl_error, _Sock, {tls_alert, {unknown_ca, _}}}, Reason),
+    %% The shutdown reason itself, not the raw `{ssl_error, Sock, Reason}'
+    %% socket event; same shape as in `t_ssl_error_client_reject_server'.
+    ?assertMatch({tls_alert, {unknown_ca, _}}, Reason),
+    ok.
+
+%% Receiving bytes that do not parse as an MQTT frame — e.g. the TLS alert a
+%% TLS listener sends back when a plain TCP client posts MQTT CONNECT to it —
+%% must yield a compact typed error: not the raw `{tcp, Port, Data}' socket
+%% event, and no stacktrace in the reason. A fake server is used instead of a
+%% real TLS listener so the alert bytes are delivered deterministically
+%% (a real TLS stack may close the socket before the alert is flushed).
+t_frame_parse_error(_Config) ->
+    ct:timetrap({seconds, 10}),
+    {ok, L} = gen_tcp:listen(0, [binary, {active, false}, {reuseaddr, true}]),
+    {ok, Port} = inet:port(L),
+    TestPid = self(),
+    Server = spawn_link(fun() ->
+        {ok, S} = gen_tcp:accept(L, 5000),
+        {ok, _Connect} = gen_tcp:recv(S, 0, 5000),
+        %% TLS alert record: fatal (2), unexpected_message (10)
+        ok = gen_tcp:send(S, <<21, 3, 3, 0, 2, 2, 10>>),
+        TestPid ! {sent, self()},
+        %% Keep the socket open so the close does not race the data delivery.
+        receive stop -> ok after 5000 -> ok end
+    end),
+    process_flag(trap_exit, true),
+    {ok, C} = emqtt:start_link([{host, "127.0.0.1"}, {port, Port}]),
+    ?assertMatch({error, {frame_parse_error, _}}, emqtt:connect(C)),
+    receive
+        {'EXIT', C, ExitReason} ->
+            ?assertMatch({shutdown, {frame_parse_error, _}}, ExitReason)
+    after 1000 ->
+        ok
+    end,
+    receive {sent, Server} -> ok after 1000 -> ok end,
+    unlink(Server),
+    Server ! stop,
     ok.
 
 t_reconnect_enabled(Config) ->


### PR DESCRIPTION
## Summary

Improves the error reasons returned to `emqtt:connect/1` callers when the connection fails before CONNACK, so downstream users (e.g. the EMQX MQTT bridge, see emqx/emqx#18173 / emqx/emqx#18174) can classify failures without pattern-matching raw socket events or stacktraces.

Two changes in `emqtt.erl`:

1. **Frame parse failures return a compact, typed reason.** When received bytes do not parse as an MQTT frame — e.g. the TLS handshake alert a TLS listener sends back after a plain-TCP client posts CONNECT to it — `process_incoming/3` used to shut down with `{parse_packets_error, Reason, Stacktrace}`, embedding a stacktrace in the exit reason. It now shuts down with `{frame_parse_error, Reason}` and logs the details (reason, stacktrace, offending bytes) instead.

2. **`waiting_for_connack` replies with the shutdown reason, not the raw event.** The fallthrough clause replied `{error, EventContent}` for `{shutdown, _}` stops, on the assumption that the shutdown reason is always contained in the event. For socket data events that assumption does not hold: the caller got `{error, {tcp, Port, <<TLS alert bytes>>}}` — an Erlang port and raw payload — while the actual reason was discarded. It now replies `{error, ShutdownReason}`. This also makes socket errors consistent: a server-rejected TLS client certificate now returns `{error, {tls_alert, {unknown_ca, _}}}` from both the client-reject and server-reject paths (previously the server-reject path returned the raw `{ssl_error, Sock, ...}` event), and a closed socket returns `{error, tcp_closed}` instead of `{error, {tcp_closed, Sock}}`.

Return value changes (callers matching the old shapes need adjusting):

| before | after |
|---|---|
| `{error, {tcp, Port, Bytes}}` (garbage/TLS bytes) | `{error, {frame_parse_error, Reason}}` |
| `{error, {shutdown, {parse_packets_error, Reason, Stack}}}` (via exit) | `{shutdown, {frame_parse_error, Reason}}` |
| `{error, {ssl_error, Sock, TlsAlert}}` | `{error, TlsAlert}` |
| `{error, {tcp_closed, Sock}}` before CONNACK | `{error, tcp_closed}` |

Tests: new `t_frame_parse_error` case sends TLS-alert bytes from a fake server (deterministic delivery, unlike a real TLS stack which may close before flushing the alert) and asserts the typed error and exit reason; `t_ssl_error_server_reject_client` updated for the now-consistent TLS alert shape.
