### PR TITLE
feat: add shuffle_hosts option; try hosts in configured order

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ option() = {name, atom()} |
            {owner, pid()} |
            {host, host()} |
            {hosts, [{host(), inet:port_number()}]} |
+           {shuffle_hosts, boolean()} |
            {port, inet:port_number()} |
            {tcp_opts, [gen_tcp:option()]} |
            {ssl, boolean()} |
@@ -534,7 +535,11 @@ The host of the MQTT server to be connected. Host can be a hostname or an IP add
 
 `{hosts, [{Host, Port}]}`
 
-A list of hosts to connect to. If the connection to the first host fails, the client will try the next host in the list. If the connection to all hosts fails, the client will return an error. Setting this option will override the `host` option.
+A list of hosts to connect to. The hosts are tried in the given order: if the connection to the first host fails, the client will try the next host in the list. If the connection to all hosts fails, the client will return an error. Setting this option will override the `host` option.
+
+`{shuffle_hosts, boolean()}`
+
+When `true`, the `hosts` list is shuffled before every connect attempt, including reconnects, so clients spread across the listed hosts instead of all trying the first one. When `false`, the list is tried in the given order, so the first host acts as the primary and the rest as failover. Defaults to `false`.
 
 `{port, Port}`
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # 1.16.0
 
+- feat: add the `shuffle_hosts` option. When `true`, the `hosts` list is
+  shuffled before every connect attempt (including reconnects), so clients
+  with several brokers spread across them instead of all trying the first one.
+  Defaults to `false`, which keeps the configured order: first host primary,
+  the rest failover.
 - fix: try the `hosts` list in the configured order. `init/2` built the list
   with a prepending fold, which reversed it, so `{hosts, [A, B]}` tried `B`
   first. The first entry is now tried first, as the README has always stated.

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# 1.16.0
+
+- fix: try the `hosts` list in the configured order. `init/2` built the list
+  with a prepending fold, which reversed it, so `{hosts, [A, B]}` tried `B`
+  first. The first entry is now tried first, as the README has always stated.
+
 # 1.15.4
 
 - fix: return clean, typed error reasons from failed connect attempts.

--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -151,6 +151,8 @@
                 | {msg_handler, msg_handler()}
                 | {host, host()}
                 | {hosts, [{host(), inet:port_number()}]}
+                %% if true, the hosts list is shuffled before every connect attempt
+                | {shuffle_hosts, boolean()}
                 | {port, inet:port_number()}
                 | {tcp_opts, [gen_tcp:option()]}
                 | {ssl, boolean()}
@@ -787,7 +789,6 @@ maybe_rand_id(_, ?NO_CLIENT_ID) -> random_client_id();
 maybe_rand_id(_, ID) -> ID.
 
 random_client_id() ->
-    _ = rand:seed(exsplus, erlang:timestamp()),
     I1 = rand:uniform(round(math:pow(2, 48))) - 1,
     I2 = rand:uniform(round(math:pow(2, 32))) - 1,
     {ok, Host} = inet:gethostname(),
@@ -813,6 +814,9 @@ init([{hosts, Hosts} | Opts], State) ->
                           (Host) -> {Host, 1883}
                        end, Hosts),
     init(Opts, State#state{hosts = Hosts1});
+init([{shuffle_hosts, true} | Opts], State = #state{extra = Extra}) ->
+    %% save only non-default value to keep client's default state footprint small
+    init(Opts, State#state{extra = Extra#{shuffle_hosts => true}});
 init([{tcp_opts, TcpOpts} | Opts], State = #state{sock_opts = SockOpts}) ->
     init(Opts, State#state{sock_opts = merge_opts(SockOpts, TcpOpts)});
 init([{quic_opts, {_ConnOpts, _StreamOpts}} = QuicOpts | Opts], State = #state{sock_opts = SockOpts}) ->
@@ -2281,10 +2285,23 @@ sock_connect(ConnMod, [{Host, Port} | Hosts], SockOpts, Timeout, _LastErr) ->
             sock_connect(ConnMod, Hosts, SockOpts, Timeout, Error)
     end.
 
+%% The list of `{Host, Port}' pairs to try, head first.
+%% Called on every connect attempt (initial connect and each reconnect),
+%% so with `shuffle_hosts' each attempt gets a fresh random order.
 hosts(#state{hosts = [], host = Host, port = Port}) ->
     [{host(Host), Port}];
-hosts(#state{hosts = Hosts}) ->
-    [{host(Host), Port} || {Host, Port} <- Hosts].
+hosts(#state{hosts = Hosts, extra = Extra}) ->
+    Hosts1 = [{host(Host), Port} || {Host, Port} <- Hosts],
+    case maps:get(shuffle_hosts, Extra, false) of
+        true -> shuffle(Hosts1);
+        false -> Hosts1
+    end.
+
+%% `rand:uniform/0' seeds the process on first use; no explicit seeding,
+%% and no time-based seed, so clients started in the same instant do not
+%% all pick the same order.
+shuffle(List) ->
+    [X || {_, X} <- lists:keysort(1, [{rand:uniform(), X} || X <- List])].
 
 host(Bin) when is_binary(Bin) -> binary_to_list(Bin);
 host(Host) -> Host.

--- a/src/emqtt.erl
+++ b/src/emqtt.erl
@@ -808,12 +808,10 @@ init([{host, Host} | Opts], State) ->
 init([{port, Port} | Opts], State) ->
     init(Opts, State#state{port = Port});
 init([{hosts, Hosts} | Opts], State) ->
-    Hosts1 =
-    lists:foldl(fun({Host, Port}, Acc) ->
-                    [{Host, Port}|Acc];
-                   (Host, Acc) ->
-                    [{Host, 1883}|Acc]
-                end, [], Hosts),
+    %% Keep the configured order: the list is tried head-first.
+    Hosts1 = lists:map(fun({Host, Port}) -> {Host, Port};
+                          (Host) -> {Host, 1883}
+                       end, Hosts),
     init(Opts, State#state{hosts = Hosts1});
 init([{tcp_opts, TcpOpts} | Opts], State = #state{sock_opts = SockOpts}) ->
     init(Opts, State#state{sock_opts = merge_opts(SockOpts, TcpOpts)});

--- a/test/emqtt_SUITE.erl
+++ b/test/emqtt_SUITE.erl
@@ -33,6 +33,11 @@
 -define(WILD_TOPICS, [<<"TopicA/+">>, <<"+/C">>, <<"#">>, <<"/#">>, <<"/+">>,
                       <<"+/+">>, <<"TopicA/#">>]).
 
+%% The broker's TCP listener port. Tests that need a real listener use TCP
+%% regardless of the group, because host selection is transport independent
+%% and a QUIC (UDP) connect to a dead port only fails by timeout.
+-define(TCP_PORT, 1883).
+
 -define(WAIT(Pattern, Result),
         receive
             Pattern ->
@@ -98,6 +103,8 @@ groups() ->
        t_pause_resume,
        t_init,
        t_init_external_secret,
+       t_hosts_order_preserved,
+       t_hosts_failover,
        t_connected,
        t_qos2_flow_autoack_never,
        t_ssl_error_client_reject_server,
@@ -1364,6 +1371,28 @@ t_init_external_secret(Config) ->
     {ok, _} = emqtt:ConnFun(C),
     ok = emqtt:disconnect(C).
 
+%% The `hosts' list must be tried in the configured order, head first.
+%% Regression test: `init/2' used to build the list with a prepending fold,
+%% which reversed it.
+t_hosts_order_preserved(Config) ->
+    ConnFun = ?config(conn_fun, Config),
+    process_flag(trap_exit, true),
+    Hosts = [{{127,0,0,1}, 10001}, {{127,0,0,2}, 10002}, {{127,0,0,3}, 10003}],
+    ok = mock_connect_recorder(conn_mod(ConnFun)),
+    {ok, C} = emqtt:start_link([{hosts, Hosts}]),
+    %% every connect fails, so the last host's error is returned
+    ?assertEqual({error, {refused, {127,0,0,3}, 10003}}, emqtt:ConnFun(C)),
+    ?assertEqual(Hosts, collect_connect_attempts()),
+    ok.
+
+%% When the first host is down, the client connects to the next one.
+t_hosts_failover(_Config) ->
+    DeadPort = unused_port(),
+    {ok, C} = emqtt:start_link([{hosts, [{{127,0,0,1}, DeadPort},
+                                         {{127,0,0,1}, ?TCP_PORT}]}]),
+    {ok, _} = emqtt:connect(C),
+    ok = emqtt:disconnect(C).
+
 t_initialized(_) ->
     error('TODO').
 
@@ -1832,3 +1861,34 @@ unmock_quic() ->
         false ->
             ok
     end.
+
+%% Mock `ConnMod:connect/4' so every attempt fails and is reported to the
+%% test process as `{connect_attempt, Host, Port}'.
+mock_connect_recorder(ConnMod) ->
+    Self = self(),
+    meck:new(ConnMod, [passthrough, no_history]),
+    meck:expect(ConnMod, connect,
+                fun(Host, Port, _SockOpts, _Timeout) ->
+                        Self ! {connect_attempt, Host, Port},
+                        {error, {refused, Host, Port}}
+                end),
+    ok.
+
+%% Return the recorded `{Host, Port}' connect attempts, oldest first.
+collect_connect_attempts() ->
+    receive
+        {connect_attempt, Host, Port} ->
+            [{Host, Port} | collect_connect_attempts()]
+    after 0 ->
+        []
+    end.
+
+conn_mod(quic_connect) -> emqtt_quic;
+conn_mod(connect) -> emqtt_sock.
+
+%% A TCP port nothing listens on.
+unused_port() ->
+    {ok, LSock} = gen_tcp:listen(0, [{ip, {127,0,0,1}}]),
+    {ok, Port} = inet:port(LSock),
+    ok = gen_tcp:close(LSock),
+    Port.

--- a/test/emqtt_SUITE.erl
+++ b/test/emqtt_SUITE.erl
@@ -105,6 +105,10 @@ groups() ->
        t_init_external_secret,
        t_hosts_order_preserved,
        t_hosts_failover,
+       t_shuffle_hosts_order_varies,
+       t_shuffle_hosts_disabled,
+       t_shuffle_hosts_failover,
+       t_shuffle_hosts_single,
        t_connected,
        t_qos2_flow_autoack_never,
        t_ssl_error_client_reject_server,
@@ -1392,6 +1396,66 @@ t_hosts_failover(_Config) ->
                                          {{127,0,0,1}, ?TCP_PORT}]}]),
     {ok, _} = emqtt:connect(C),
     ok = emqtt:disconnect(C).
+
+%% With `shuffle_hosts', every connect attempt tries the hosts in a fresh
+%% random order: each attempt is a permutation of the configured list, and
+%% more than one permutation shows up over many attempts. With 3 hosts and
+%% 30 attempts, the chance that all attempts pick the same order is 6^-29.
+t_shuffle_hosts_order_varies(Config) ->
+    ConnFun = ?config(conn_fun, Config),
+    process_flag(trap_exit, true),
+    Hosts = [{{127,0,0,1}, 10001}, {{127,0,0,2}, 10002}, {{127,0,0,3}, 10003}],
+    ok = mock_connect_recorder(conn_mod(ConnFun)),
+    Orders = lists:map(
+               fun(_) ->
+                       {ok, C} = emqtt:start_link([{hosts, Hosts}, {shuffle_hosts, true}]),
+                       {error, {refused, _, _}} = emqtt:ConnFun(C),
+                       collect_connect_attempts()
+               end, lists:seq(1, 30)),
+    lists:foreach(fun(Order) -> ?assertEqual(Hosts, lists:sort(Order)) end, Orders),
+    ?assert(length(lists:usort(Orders)) > 1, Orders),
+    ok.
+
+%% `{shuffle_hosts, false}' keeps the configured order.
+t_shuffle_hosts_disabled(Config) ->
+    ConnFun = ?config(conn_fun, Config),
+    process_flag(trap_exit, true),
+    Hosts = [{{127,0,0,1}, 10001}, {{127,0,0,2}, 10002}, {{127,0,0,3}, 10003}],
+    ok = mock_connect_recorder(conn_mod(ConnFun)),
+    lists:foreach(
+      fun(_) ->
+              {ok, C} = emqtt:start_link([{hosts, Hosts}, {shuffle_hosts, false}]),
+              ?assertEqual({error, {refused, {127,0,0,3}, 10003}}, emqtt:ConnFun(C)),
+              ?assertEqual(Hosts, collect_connect_attempts())
+      end, lists:seq(1, 10)),
+    ok.
+
+%% With shuffling on and only the last configured host alive, every
+%% attempt still ends up connected.
+t_shuffle_hosts_failover(_Config) ->
+    Hosts = [{{127,0,0,1}, unused_port()},
+             {{127,0,0,1}, unused_port()},
+             {{127,0,0,1}, ?TCP_PORT}],
+    lists:foreach(
+      fun(_) ->
+              {ok, C} = emqtt:start_link([{hosts, Hosts}, {shuffle_hosts, true}]),
+              {ok, _} = emqtt:connect(C),
+              ok = emqtt:disconnect(C)
+      end, lists:seq(1, 10)),
+    ok.
+
+%% Shuffling a single-entry list, or the `host'/`port' fallback used when
+%% `hosts' is not set, is a no-op.
+t_shuffle_hosts_single(_Config) ->
+    {ok, C1} = emqtt:start_link([{hosts, [{{127,0,0,1}, ?TCP_PORT}]},
+                                 {shuffle_hosts, true}]),
+    {ok, _} = emqtt:connect(C1),
+    ok = emqtt:disconnect(C1),
+    {ok, C2} = emqtt:start_link([{host, {127,0,0,1}},
+                                 {port, ?TCP_PORT},
+                                 {shuffle_hosts, true}]),
+    {ok, _} = emqtt:connect(C2),
+    ok = emqtt:disconnect(C2).
 
 t_initialized(_) ->
     error('TODO').


### PR DESCRIPTION
## Summary

Two changes to how the `hosts` option is used.

1. **fix: try the `hosts` list in the configured order.**
   `init/2` built the list with a prepending fold, which reversed it, so `{hosts, [A, B]}` tried `B` first. Nothing documented this; the README says the first host is tried first. The list is now stored in the configured order.

2. **feat: add `{shuffle_hosts, boolean()}`, default `false`.**
   When `true`, the list is shuffled before every connect attempt, including reconnects, so clients with several brokers spread across them instead of all trying the first one.

### Why opt-in

The README documents ordered failover for `hosts`, so existing callers may rely on the first entry being the primary. Shuffling by default would silently remove that, and emqtt ships in EMQX bridges and cluster-link as well as in third-party projects. Callers that want spreading set one flag.

### Why the reversal is fixed too

With shuffling off (the default) the order is observable, so it has to mean what it says. It also removes a trap for the next reader.

### Coordinate with emqx/emqx#18409

`emqx_cluster_link` pre-reverses its host list to compensate for the old reversal. Once EMQX picks up this release, that workaround puts the list in the wrong order and must be removed in the same EMQX release. If cluster-link wants to spread connections, it should pass `{shuffle_hosts, true}` instead.

### Other

- `random_client_id/0` no longer seeds `rand` from `erlang:timestamp()`. The shuffle runs in the same process, and a bare timestamp seed would give clients started in the same microsecond the same order. `rand` self-seeds from pid, system time, and a unique integer, which is stronger for the client id as well.
- Changelog: `1.16.0`, a minor bump because it adds an option and changes the observable `hosts` order.

## Tests

- `t_hosts_order_preserved`: captures `ConnMod:connect/4` calls and asserts the exact order. Fails on `master`.
- `t_hosts_failover`: dead first host, live second host, connects.
- `t_shuffle_hosts_order_varies`: 30 attempts with 3 hosts; each attempt is a permutation, and more than one permutation appears (false-failure probability 6^-29).
- `t_shuffle_hosts_disabled`: `{shuffle_hosts, false}` keeps the order.
- `t_shuffle_hosts_failover`: shuffle on, only the last of 3 hosts alive, 10 attempts all connect.
- `t_shuffle_hosts_single`: single-entry list and the `host`/`port` fallback with shuffle on.
